### PR TITLE
Remove `Result` from internal usage, move to cofhejs boundary

### DIFF
--- a/src/core/permit/permit.ts
+++ b/src/core/permit/permit.ts
@@ -150,7 +150,6 @@ export class Permit implements PermitInterface, PermitMetadata {
 
   /**
    * Creates a `Permit` from a serialized permit, hydrating methods and classes
-   * NOTE: Does not return a stringified permit
    *
    * @param {SerializedPermit} - Permit structure excluding classes
    * @returns {Permit} - New instance of Permit class
@@ -220,8 +219,7 @@ export class Permit implements PermitInterface, PermitMetadata {
   };
 
   /**
-   * Returns a serializable permit instance, removing classes and methods.
-   * NOTE: Does not return a stringified permit
+   * Serializes the permit, removing classes and methods.
    */
   serialize = (): SerializedPermit => {
     const { sealingPair, ...permit } = this.getInterface();
@@ -236,9 +234,11 @@ export class Permit implements PermitInterface, PermitMetadata {
   };
 
   /**
-   * Extracts a contract input ready permission from this permit.
+   * Extracts a permission from this permit ready for use in the query decrypt/sealoutput flows.
    * The permission inherits most fields from the permit, however
    * `permit.sealingPair` is removed and replaced by `permit.sealingPair.publicKey` in the `sealingKey` field.
+   * `permit.type` is removed, the type is determined on-chain by which populated fields are present.
+   * `permit.name` is removed, the name is used only for organization and UI purposes.
    *
    * @permit {boolean} skipValidation - Flag to prevent running validation on the permit before returning the extracted permission. Used internally.
    * @returns {Permission}

--- a/src/core/sdk/index.ts
+++ b/src/core/sdk/index.ts
@@ -537,9 +537,6 @@ export async function decrypt<U extends FheTypes>(
     });
   }
 
-  console.log("decrypt :: resolvedAccount", resolvedAccount);
-  console.log("decrypt :: resolvedHash", resolvedHash);
-
   const permit = permitStore.getPermit(resolvedAccount, resolvedHash);
   if (permit == null) {
     throw new CofhejsError({

--- a/src/core/sdk/index.ts
+++ b/src/core/sdk/index.ts
@@ -14,13 +14,13 @@ import {
   PermitOptions,
   PermitInterface,
   Permission,
-  Result,
-  ResultErr,
-  ResultOk,
   InitializationParams,
   EncryptableItem,
   FheTypes,
   UnsealedItem,
+  CofhejsError,
+  CofhejsErrorCode,
+  wrapFunction,
 } from "../../types";
 import { mockDecrypt, mockSealOutput } from "./testnet";
 import { bytesToBigInt } from "../utils";
@@ -37,25 +37,28 @@ export const initializeCore = async (
     ignoreErrors?: boolean;
     generatePermit?: boolean;
   },
-): Promise<Result<Permit | undefined>> => {
+): Promise<Permit | undefined> => {
   if (params.provider == null)
-    return ResultErr(
-      "initialize :: missing provider - Please provide an AbstractProvider interface",
-    );
+    throw new CofhejsError({
+      code: CofhejsErrorCode.MissingProviderParam,
+      message: "Missing initialization parameter `provider`",
+    });
 
   if (params.securityZones != null && params.securityZones.length === 0)
-    return ResultErr(
-      "initialize :: a list of securityZones was provided, but it is empty",
-    );
+    throw new CofhejsError({
+      code: CofhejsErrorCode.MissingSecurityZonesParam,
+      message:
+        "Initialization parameter provided but empty `securityZones = []`",
+    });
 
   await _store_initialize(params);
 
   // `generatePermit` must set to `false` to early exit here
-  if (params.generatePermit === false) return ResultOk(undefined);
+  if (params.generatePermit === false) return undefined;
 
   // Return the existing active permit
-  const userActivePermit = getPermit();
-  if (userActivePermit.success) return userActivePermit;
+  const userActivePermit = getPermit_asResult();
+  if (userActivePermit.success) return userActivePermit.data;
 
   // Create permit and return it
   return createPermit();
@@ -66,7 +69,7 @@ export const initializeCore = async (
  */
 const _checkInitialized = (
   state: SdkStore,
-  options?: {
+  requirements?: {
     fheKeys?: boolean;
     provider?: boolean;
     signer?: boolean;
@@ -75,44 +78,55 @@ const _checkInitialized = (
     thresholdNetworkUrl?: boolean;
   },
 ) => {
-  if (
-    !state.isTestnet &&
-    options?.fheKeys !== false &&
-    !state.fheKeysInitialized
-  ) {
-    return ResultErr("cofhejs not initialized. Use `cofhejs.initialize(...)`.");
+  const {
+    fheKeys,
+    provider,
+    signer,
+    coFheUrl,
+    verifierUrl,
+    thresholdNetworkUrl,
+  } = requirements ?? {};
+
+  if (!state.isTestnet && fheKeys !== false && !state.fheKeysInitialized) {
+    throw new CofhejsError({
+      code: CofhejsErrorCode.NotInitialized,
+      message: "FHE publicKey or CRS not initialized.",
+    });
   }
 
-  if (!state.isTestnet && options?.coFheUrl !== false && !state.coFheUrl)
-    return ResultErr(
-      "cofhejs not initialized with a coFheUrl. Set `coFheUrl` in `cofhejs.initialize`.",
-    );
+  if (!state.isTestnet && coFheUrl !== false && !state.coFheUrl)
+    throw new CofhejsError({
+      code: CofhejsErrorCode.NotInitialized,
+      message: "`coFheUrl` missing from `cofhejs.initialize`.",
+    });
 
-  if (!state.isTestnet && options?.verifierUrl !== false && !state.verifierUrl)
-    return ResultErr(
-      "cofhejs not initialized with a verifierUrl. Set `verifierUrl` in `cofhejs.initialize`.",
-    );
+  if (!state.isTestnet && verifierUrl !== false && !state.verifierUrl)
+    throw new CofhejsError({
+      code: CofhejsErrorCode.NotInitialized,
+      message: "`verifierUrl` missing from `cofhejs.initialize`.",
+    });
 
   if (
     !state.isTestnet &&
-    options?.thresholdNetworkUrl !== false &&
+    thresholdNetworkUrl !== false &&
     !state.thresholdNetworkUrl
   )
-    return ResultErr(
-      "cofhejs not initialized with a thresholdNetworkUrl. Set `thresholdNetworkUrl` in `cofhejs.initialize`.",
-    );
+    throw new CofhejsError({
+      code: CofhejsErrorCode.NotInitialized,
+      message: "`thresholdNetworkUrl` missing from `cofhejs.initialize`.",
+    });
 
-  if (options?.provider !== false && !state.providerInitialized)
-    return ResultErr(
-      "cofhejs not initialized with valid provider. Use `cofhejs.initialize(...)` with a valid provider that satisfies `AbstractProvider`.",
-    );
+  if (provider !== false && !state.providerInitialized)
+    throw new CofhejsError({
+      code: CofhejsErrorCode.ProviderNotInitialized,
+      message: "`provider` missing from `cofhejs.initialize`.",
+    });
 
-  if (options?.signer !== false && !state.signerInitialized)
-    return ResultErr(
-      "cofhejs not initialized with a valid signer. Use `cofhejs.initialize(...)` with a valid signer that satisfies `AbstractSigner`.",
-    );
-
-  return ResultOk(null);
+  if (signer !== false && !state.signerInitialized)
+    throw new CofhejsError({
+      code: CofhejsErrorCode.SignerNotInitialized,
+      message: "`signer` missing from `cofhejs.initialize`.",
+    });
 };
 
 // Permit
@@ -129,12 +143,10 @@ const _checkInitialized = (
  */
 export const createPermit = async (
   options?: PermitOptions,
-): Promise<Result<Permit>> => {
+): Promise<Permit> => {
   const state = _sdkStore.getState();
 
-  const initialized = _checkInitialized(state);
-  if (!initialized.success)
-    return ResultErr(`${createPermit.name} :: ${initialized.error}`);
+  _checkInitialized(state);
 
   const optionsWithDefaults: PermitOptions = {
     type: "self",
@@ -142,18 +154,12 @@ export const createPermit = async (
     ...options,
   };
 
-  let permit: Permit;
-  try {
-    permit = await Permit.createAndSign(optionsWithDefaults, state.signer);
-  } catch (e) {
-    console.log("createPermit :: e", e);
-    return ResultErr(`${createPermit.name} :: ${e}`);
-  }
+  const permit = await Permit.createAndSign(optionsWithDefaults, state.signer);
 
   permitStore.setPermit(state.account!, permit);
   permitStore.setActivePermitHash(state.account!, permit.getHash());
 
-  return ResultOk(permit);
+  return permit;
 };
 
 /**
@@ -166,20 +172,14 @@ export const createPermit = async (
  */
 export const importPermit = async (
   imported: string | PermitInterface,
-): Promise<Result<Permit>> => {
+): Promise<Permit> => {
   const state = _sdkStore.getState();
 
-  const initialized = _checkInitialized(state);
-  if (!initialized.success)
-    return ResultErr(`${createPermit.name} :: ${initialized.error}`);
+  _checkInitialized(state);
 
   // Import validation
   if (typeof imported === "string") {
-    try {
-      imported = JSON.parse(imported);
-    } catch (e) {
-      return ResultErr(`importPermit :: json parsing failed - ${e}`);
-    }
+    imported = JSON.parse(imported);
   }
 
   const {
@@ -187,41 +187,43 @@ export const importPermit = async (
     data: parsedPermit,
     error: permitParsingError,
   } = PermitParamsValidator.safeParse(imported as PermitInterface);
+
   if (!success) {
     const errorString = Object.entries(permitParsingError.flatten().fieldErrors)
       .map(([field, err]) => `- ${field}: ${err}`)
       .join("\n");
-    return ResultErr(`importPermit :: invalid permit data - ${errorString}`);
+
+    throw new CofhejsError({
+      code: CofhejsErrorCode.InvalidPermitData,
+      message: errorString,
+    });
   }
   if (parsedPermit.type !== "self") {
     if (parsedPermit.issuer === state.account) parsedPermit.type = "sharing";
     else if (parsedPermit.recipient === state.account)
       parsedPermit.type = "recipient";
     else {
-      return ResultErr(
-        `importPermit :: invalid Permit - connected account <${state.account}> is not issuer or recipient`,
-      );
+      throw new CofhejsError({
+        code: CofhejsErrorCode.InvalidPermitData,
+        message: `Connected account <${state.account}> is not issuer or recipient`,
+      });
     }
   }
 
-  let permit: Permit;
-  try {
-    permit = await Permit.create(parsedPermit as PermitInterface);
-  } catch (e) {
-    return ResultErr(`importPermit :: ${e}`);
-  }
+  const permit = await Permit.create(parsedPermit as PermitInterface);
 
   const { valid, error } = permit.isValid();
   if (!valid) {
-    return ResultErr(
-      `importPermit :: newly imported permit is invalid - ${error}`,
-    );
+    throw new CofhejsError({
+      code: CofhejsErrorCode.InvalidPermitData,
+      message: `Imported permit is invalid - ${error}`,
+    });
   }
 
   permitStore.setPermit(state.account!, permit);
   permitStore.setActivePermitHash(state.account!, permit.getHash());
 
-  return ResultOk(permit);
+  return permit;
 };
 
 /**
@@ -231,22 +233,21 @@ export const importPermit = async (
  *
  * @param {string} hash - The `Permit.getHash` of the target permit.
  */
-export const selectActivePermit = (hash: string): Result<Permit> => {
+export const selectActivePermit = (hash: string): Permit => {
   const state = _sdkStore.getState();
 
-  const initialized = _checkInitialized(state);
-  if (!initialized.success)
-    return ResultErr(`${selectActivePermit.name} :: ${initialized.error}`);
+  _checkInitialized(state);
 
   const permit = permitStore.getPermit(state.account, hash);
   if (permit == null)
-    return ResultErr(
-      `${selectActivePermit.name} :: Permit with hash <${hash}> not found`,
-    );
+    throw new CofhejsError({
+      code: CofhejsErrorCode.PermitNotFound,
+      message: `Permit with hash <${hash}> not found`,
+    });
 
   permitStore.setActivePermitHash(state.account!, permit.getHash());
 
-  return ResultOk(permit);
+  return permit;
 };
 
 /**
@@ -256,27 +257,33 @@ export const selectActivePermit = (hash: string): Result<Permit> => {
  * @param {string} hash - Optional `Permit.getHash` of the permit.
  * @returns {Result<Permit>} - The active permit or permit associated with `hash` as a Result object.
  */
-export const getPermit = (hash?: string): Result<Permit> => {
+export const getPermit = (hash?: string): Permit => {
   const state = _sdkStore.getState();
 
-  const initialized = _checkInitialized(state);
-  if (!initialized.success)
-    return ResultErr(`${getPermit.name} :: ${initialized.error}`);
+  _checkInitialized(state);
 
   if (hash == null) {
     const permit = permitStore.getActivePermit(state.account);
     if (permit == null)
-      return ResultErr(`getPermit :: active permit not found`);
+      throw new CofhejsError({
+        code: CofhejsErrorCode.PermitNotFound,
+        message: `Active permit not found`,
+      });
 
-    return ResultOk(permit);
+    return permit;
   }
 
   const permit = permitStore.getPermit(state.account, hash);
   if (permit == null)
-    return ResultErr(`getPermit :: permit with hash <${hash}> not found`);
+    throw new CofhejsError({
+      code: CofhejsErrorCode.PermitNotFound,
+      message: `Permit with hash <${hash}> not found`,
+    });
 
-  return ResultOk(permit);
+  return permit;
 };
+
+export const getPermit_asResult = wrapFunction(getPermit);
 
 /**
  * Retrieves a stored permission based on the permit's hash.
@@ -286,31 +293,26 @@ export const getPermit = (hash?: string): Result<Permit> => {
  * @param {string} hash - Optional hash of the permission to get, defaults to active permit's permission
  * @returns {Result<Permission>} - The active permission or permission associated with `hash`, as a result object.
  */
-export const getPermission = (hash?: string): Result<Permission> => {
-  const permitResult = getPermit(hash);
-  if (!permitResult.success)
-    return ResultErr(`${getPermission.name} :: ${permitResult.error}`);
-
-  return ResultOk(permitResult.data.getPermission());
+export const getPermission = (hash?: string): Permission => {
+  const permit = getPermit(hash);
+  return permit.getPermission();
 };
 
 /**
  * Exports all stored permits.
  * @returns {Result<Record<string, Permit>>} - All stored permits.
  */
-export const getAllPermits = (): Result<Record<string, Permit>> => {
+export const getAllPermits = (): Record<string, Permit> => {
   const state = _sdkStore.getState();
 
-  const initialized = _checkInitialized(state);
-  if (!initialized.success)
-    return ResultErr(`${getAllPermits.name} :: ${initialized.error}`);
+  _checkInitialized(state);
 
-  return ResultOk(permitStore.getPermits(state.account));
+  return permitStore.getPermits(state.account);
 };
 
 // Encrypt (Steps)
 
-export function encryptGetKeys(): Result<{
+export function encryptGetKeys(): {
   fhePublicKey: Uint8Array;
   crs: Uint8Array;
   coFheUrl: string;
@@ -318,50 +320,47 @@ export function encryptGetKeys(): Result<{
   thresholdNetworkUrl: string;
   account: string;
   chainId: string;
-}> {
+} {
   const state = _sdkStore.getState();
 
   // Only need to check `fheKeysInitialized`, signer and provider not needed for encryption
-  const initialized = _checkInitialized(state, {
-    provider: false,
-    signer: false,
-  });
-  if (!initialized.success) return ResultErr(`encrypt :: ${initialized.error}`);
+  _checkInitialized(state);
 
   if (state.account == null)
-    return ResultErr("encrypt :: account uninitialized");
+    throw new CofhejsError({
+      code: CofhejsErrorCode.AccountUninitialized,
+      message: "account uninitialized",
+    });
 
   if (state.chainId == null)
-    return ResultErr("encrypt :: chainId uninitialized");
+    throw new CofhejsError({
+      code: CofhejsErrorCode.ChainIdUninitialized,
+      message: "chainId uninitialized",
+    });
 
   const fhePublicKey = _store_getConnectedChainFheKey(0);
   if (fhePublicKey == null)
-    return ResultErr("encrypt :: fheKey for current chain not found");
+    throw new CofhejsError({
+      code: CofhejsErrorCode.FheKeyNotFound,
+      message: "fheKey for current chain not found",
+    });
 
   const crs = _store_getCrs(state.chainId);
   if (crs == null)
-    return ResultErr("encrypt :: CRS for current chain not found");
+    throw new CofhejsError({
+      code: CofhejsErrorCode.CrsNotFound,
+      message: "CRS for current chain not found",
+    });
 
-  const coFheUrl = state.coFheUrl;
-  if (coFheUrl == null) return ResultErr("encrypt :: coFheUrl not initialized");
-
-  const verifierUrl = state.verifierUrl;
-  if (verifierUrl == null)
-    return ResultErr("encrypt :: verifierUrl not initialized");
-
-  const thresholdNetworkUrl = state.thresholdNetworkUrl;
-  if (thresholdNetworkUrl == null)
-    return ResultErr("encrypt :: thresholdNetworkUrl not initialized");
-
-  return ResultOk({
+  return {
     fhePublicKey,
     crs,
-    coFheUrl,
-    verifierUrl,
-    thresholdNetworkUrl,
+    coFheUrl: state.coFheUrl!,
+    verifierUrl: state.verifierUrl!,
+    thresholdNetworkUrl: state.thresholdNetworkUrl!,
     account: state.account,
     chainId: state.chainId,
-  });
+  };
 }
 
 export function encryptExtract<T>(item: T): EncryptableItem[];
@@ -441,37 +440,39 @@ export async function unseal<U extends FheTypes>(
   utype: U,
   account?: string,
   permitHash?: string,
-): Promise<Result<UnsealedItem<U>>> {
-  const initialized = _checkInitialized(_sdkStore.getState());
-  if (!initialized.success)
-    return ResultErr(`${unseal.name} :: ${initialized.error}`);
+): Promise<UnsealedItem<U>> {
+  _checkInitialized(_sdkStore.getState());
+  const thresholdNetworkUrl = _sdkStore.getState().thresholdNetworkUrl!;
+
+  const provider = _sdkStore.getState().provider;
+  if (provider == null)
+    throw new CofhejsError({
+      code: CofhejsErrorCode.ProviderNotInitialized,
+      message: "provider not initialized",
+    });
 
   const resolvedAccount = account ?? _sdkStore.getState().account;
   const resolvedHash =
     permitHash ?? permitStore.getActivePermitHash(resolvedAccount);
+
   if (resolvedAccount == null || resolvedHash == null) {
-    return ResultErr(
-      `unseal :: Permit hash not provided and active Permit not found`,
-    );
+    throw new CofhejsError({
+      code: CofhejsErrorCode.PermitNotFound,
+      message: `Permit hash not provided and active Permit not found`,
+    });
   }
 
   const permit = permitStore.getPermit(resolvedAccount, resolvedHash);
   if (permit == null) {
-    return ResultErr(
-      `unseal :: Permit with account <${account}> and hash <${permitHash}> not found`,
-    );
+    throw new CofhejsError({
+      code: CofhejsErrorCode.PermitNotFound,
+      message: `Permit with account <${account}> and hash <${permitHash}> not found`,
+    });
   }
-
-  const provider = _sdkStore.getState().provider;
-  if (provider == null) return ResultErr("unseal :: provider uninitialized");
 
   if (_sdkStore.getState().isTestnet) {
     return mockSealOutput(provider, ctHash, utype, permit);
   }
-
-  const thresholdNetworkUrl = _sdkStore.getState().thresholdNetworkUrl;
-  if (thresholdNetworkUrl == null)
-    return ResultErr("unseal :: thresholdNetworkUrl not initialized");
 
   let sealed: EthEncryptedData | undefined;
 
@@ -490,26 +491,31 @@ export async function unseal<U extends FheTypes>(
     });
 
     const sealOutput = await sealOutputRes.json();
-    console.log("unseal sealOutput", sealOutput);
     sealed = sealOutput.sealed;
-    console.log("unseal sealed", sealed);
   } catch (e) {
-    console.log("unseal :: sealOutput request failed ::", e);
-    return ResultErr(`unseal :: sealOutput request failed :: ${e}`);
+    throw new CofhejsError({
+      code: CofhejsErrorCode.SealOutputFailed,
+      message: `sealOutput request failed`,
+    });
   }
 
   if (sealed == null) {
-    return ResultErr("unseal :: sealed data not found");
+    throw new CofhejsError({
+      code: CofhejsErrorCode.SealOutputReturnedNull,
+      message: "sealed data not found",
+    });
   }
 
   const unsealed = permit.unseal(sealed);
-  console.log("unsealed", unsealed);
 
   if (!isValidUtype(utype)) {
-    return ResultErr(`unseal :: invalid utype :: ${utype}`);
+    throw new CofhejsError({
+      code: CofhejsErrorCode.InvalidUtype,
+      message: `invalid utype :: ${utype}`,
+    });
   }
 
-  return ResultOk(convertViaUtype(utype, unsealed)) as Result<UnsealedItem<U>>;
+  return convertViaUtype(utype, unsealed);
 }
 
 export async function decrypt<U extends FheTypes>(
@@ -517,18 +523,18 @@ export async function decrypt<U extends FheTypes>(
   utype: U,
   account?: string,
   permitHash?: string,
-): Promise<Result<UnsealedItem<U>>> {
-  const initialized = _checkInitialized(_sdkStore.getState());
-  if (!initialized.success)
-    return ResultErr(`${decrypt.name} :: ${initialized.error}`);
+): Promise<UnsealedItem<U>> {
+  _checkInitialized(_sdkStore.getState());
+  const thresholdNetworkUrl = _sdkStore.getState().thresholdNetworkUrl!;
 
   const resolvedAccount = account ?? _sdkStore.getState().account;
   const resolvedHash =
     permitHash ?? permitStore.getActivePermitHash(resolvedAccount);
   if (resolvedAccount == null || resolvedHash == null) {
-    return ResultErr(
-      `decrypt :: Permit hash not provided and active Permit not found`,
-    );
+    throw new CofhejsError({
+      code: CofhejsErrorCode.PermitNotFound,
+      message: `Permit hash not provided and active Permit not found`,
+    });
   }
 
   console.log("decrypt :: resolvedAccount", resolvedAccount);
@@ -536,20 +542,18 @@ export async function decrypt<U extends FheTypes>(
 
   const permit = permitStore.getPermit(resolvedAccount, resolvedHash);
   if (permit == null) {
-    return ResultErr(
-      `decrypt :: Permit with account <${account}> and hash <${permitHash}> not found`,
-    );
+    throw new CofhejsError({
+      code: CofhejsErrorCode.PermitNotFound,
+      message: `Permit with account <${account}> and hash <${permitHash}> not found`,
+    });
   }
 
   if (_sdkStore.getState().isTestnet) {
     return mockDecrypt(_sdkStore.getState().provider!, ctHash, utype, permit);
   }
 
-  const thresholdNetworkUrl = _sdkStore.getState().thresholdNetworkUrl;
-  if (thresholdNetworkUrl == null)
-    return ResultErr("decrypt :: thresholdNetworkUrl not initialized");
-
   let decrypted: bigint | undefined;
+  let decryptOutput: any | undefined;
 
   try {
     const body = {
@@ -557,10 +561,6 @@ export async function decrypt<U extends FheTypes>(
       host_chain_id: Number(_sdkStore.getState().chainId),
       permit: permit.getPermission(),
     };
-    console.log(
-      "decrypt thresholdNetworkUrl",
-      `${thresholdNetworkUrl}/decrypt`,
-    );
 
     const decryptOutputRes = await fetch(`${thresholdNetworkUrl}/decrypt`, {
       method: "POST",
@@ -569,30 +569,39 @@ export async function decrypt<U extends FheTypes>(
       },
       body: JSON.stringify(body),
     });
-    console.log("decryptOutputRes", decryptOutputRes);
-    const decryptOutput = await decryptOutputRes.json();
-    console.log("decryptOutput", decryptOutput);
+
+    decryptOutput = await decryptOutputRes.json();
     decrypted = bytesToBigInt(decryptOutput.decrypted);
+  } catch (e: unknown) {
+    throw new CofhejsError({
+      code: CofhejsErrorCode.DecryptFailed,
+      message: `decrypt request failed`,
+      cause: e as Error,
+    });
+  }
 
-    if (decrypted == null) {
-      return ResultErr("decrypt :: decrypted data not found");
-    }
+  if (decryptOutput == null || decrypted == null) {
+    throw new CofhejsError({
+      code: CofhejsErrorCode.DecryptReturnedNull,
+      message: "decrypted data not found",
+    });
+  }
 
-    if (decryptOutput.encryption_type !== utype) {
-      return ResultErr(
-        `decrypt :: unexpected encryption type :: received ${decryptOutput.encryption_type}, expected ${utype}`,
-      );
-    }
-  } catch (e) {
-    console.log("decrypt :: decrypt request failed ::", e);
-    return ResultErr(`decrypt :: decrypt request failed :: ${e}`);
+  if (decryptOutput.encryption_type !== utype) {
+    throw new CofhejsError({
+      code: CofhejsErrorCode.InvalidUtype,
+      message: `unexpected encryption type :: received ${decryptOutput.encryption_type}, expected ${utype}`,
+    });
   }
 
   if (!isValidUtype(utype)) {
-    return ResultErr(`decrypt :: invalid utype :: ${utype}`);
+    throw new CofhejsError({
+      code: CofhejsErrorCode.InvalidUtype,
+      message: `invalid utype :: ${utype}`,
+    });
   }
 
-  return ResultOk(convertViaUtype(utype, decrypted)) as Result<UnsealedItem<U>>;
+  return convertViaUtype(utype, decrypted);
 }
 
 export * from "./initializers";

--- a/src/core/sdk/testnet.ts
+++ b/src/core/sdk/testnet.ts
@@ -100,10 +100,6 @@ async function mockZkVerifySign(
   });
 
   // Decode zkVerifyCalcCtHashesPacked result
-  console.log(
-    "zkVerifyCalcCtHashesPackedResult",
-    zkVerifyCalcCtHashesPackedResult,
-  );
   const [ctHashes] = zkVerifierIface.decodeFunctionResult(
     "zkVerifyCalcCtHashesPacked",
     zkVerifyCalcCtHashesPackedResult,

--- a/src/core/utils/consts.ts
+++ b/src/core/utils/consts.ts
@@ -48,3 +48,135 @@ export const mockZkVerifierIface = [
   ) public view returns (uint256[] memory ctHashes)`,
   "function insertPackedCtHashes(uint256[] ctHashes, uint256[] values) public",
 ];
+
+export const mockQueryDecrypterAbi = [
+  {
+    type: "function",
+    name: "acl",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "contract ACL" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "decodeLowLevelReversion",
+    inputs: [{ name: "data", type: "bytes", internalType: "bytes" }],
+    outputs: [{ name: "error", type: "string", internalType: "string" }],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "exists",
+    inputs: [],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "initialize",
+    inputs: [
+      { name: "_taskManager", type: "address", internalType: "address" },
+      { name: "_acl", type: "address", internalType: "address" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "queryDecrypt",
+    inputs: [
+      { name: "ctHash", type: "uint256", internalType: "uint256" },
+      { name: "", type: "uint256", internalType: "uint256" },
+      {
+        name: "permission",
+        type: "tuple",
+        internalType: "struct Permission",
+        components: [
+          { name: "issuer", type: "address", internalType: "address" },
+          { name: "expiration", type: "uint64", internalType: "uint64" },
+          { name: "recipient", type: "address", internalType: "address" },
+          { name: "validatorId", type: "uint256", internalType: "uint256" },
+          {
+            name: "validatorContract",
+            type: "address",
+            internalType: "address",
+          },
+          { name: "sealingKey", type: "bytes32", internalType: "bytes32" },
+          { name: "issuerSignature", type: "bytes", internalType: "bytes" },
+          { name: "recipientSignature", type: "bytes", internalType: "bytes" },
+        ],
+      },
+    ],
+    outputs: [
+      { name: "allowed", type: "bool", internalType: "bool" },
+      { name: "error", type: "string", internalType: "string" },
+      { name: "", type: "uint256", internalType: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "querySealOutput",
+    inputs: [
+      { name: "ctHash", type: "uint256", internalType: "uint256" },
+      { name: "", type: "uint256", internalType: "uint256" },
+      {
+        name: "permission",
+        type: "tuple",
+        internalType: "struct Permission",
+        components: [
+          { name: "issuer", type: "address", internalType: "address" },
+          { name: "expiration", type: "uint64", internalType: "uint64" },
+          { name: "recipient", type: "address", internalType: "address" },
+          { name: "validatorId", type: "uint256", internalType: "uint256" },
+          {
+            name: "validatorContract",
+            type: "address",
+            internalType: "address",
+          },
+          { name: "sealingKey", type: "bytes32", internalType: "bytes32" },
+          { name: "issuerSignature", type: "bytes", internalType: "bytes" },
+          { name: "recipientSignature", type: "bytes", internalType: "bytes" },
+        ],
+      },
+    ],
+    outputs: [
+      { name: "allowed", type: "bool", internalType: "bool" },
+      { name: "error", type: "string", internalType: "string" },
+      { name: "", type: "bytes32", internalType: "bytes32" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "seal",
+    inputs: [
+      { name: "input", type: "uint256", internalType: "uint256" },
+      { name: "key", type: "bytes32", internalType: "bytes32" },
+    ],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "pure",
+  },
+  {
+    type: "function",
+    name: "taskManager",
+    inputs: [],
+    outputs: [
+      { name: "", type: "address", internalType: "contract TaskManager" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "unseal",
+    inputs: [
+      { name: "hashed", type: "bytes32", internalType: "bytes32" },
+      { name: "key", type: "bytes32", internalType: "bytes32" },
+    ],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    stateMutability: "pure",
+  },
+  { type: "error", name: "NotAllowed", inputs: [] },
+  { type: "error", name: "SealingKeyInvalid", inputs: [] },
+  { type: "error", name: "SealingKeyMissing", inputs: [] },
+] as const;

--- a/src/node/sdk.ts
+++ b/src/node/sdk.ts
@@ -22,9 +22,12 @@ import {
   EncryptStep,
   InitializationParams,
   Environment,
+  CofhejsError,
+  CofhejsErrorCode,
+  wrapFunctionAsync,
+  wrapFunction,
   Result,
-  ResultErr,
-  ResultOk,
+  Permission,
 } from "../types";
 import { initTfhe } from "./init";
 import { zkPack, zkProve, zkVerify } from "./zkPoK";
@@ -51,22 +54,20 @@ export const initialize = async (
     generatePermit?: boolean;
     environment?: Environment;
   },
-): Promise<Result<Permit | undefined>> => {
+): Promise<Permit | undefined> => {
   // Apply environment-specific defaults if environment is provided
-  const processedParamsResult = applyEnvironmentDefaults(params);
-  if (!processedParamsResult.success) {
-    return ResultErr(processedParamsResult.error);
-  }
-  const processedParams = processedParamsResult.data;
+  const processedParams = applyEnvironmentDefaults(params);
 
   // Initialize the fhevm
   await initTfhe().catch((err: unknown) => {
     if (processedParams.ignoreErrors) {
       return undefined;
     } else {
-      return ResultErr(
-        `initialize :: failed to initialize cofhejs - is the network FHE-enabled? ${err}`,
-      );
+      throw new CofhejsError({
+        code: CofhejsErrorCode.InitTfheFailed,
+        message: `initializing TFHE failed - is the network FHE-enabled?`,
+        cause: err instanceof Error ? err : undefined,
+      });
     }
   });
 
@@ -83,30 +84,24 @@ export const initialize = async (
 
 async function initializeWithViem(
   params: ViemInitializerParams,
-): Promise<Result<Permit | undefined>> {
-  const result = await getViemAbstractProviders(params);
-  if (!result.success) {
-    return ResultErr(result.error);
-  }
+): Promise<Permit | undefined> {
+  const { provider, signer } = await getViemAbstractProviders(params);
 
   return initialize({
-    provider: result.data.provider!,
-    signer: result.data.signer!,
+    provider,
+    signer,
     ...params,
   });
 }
 
 async function initializeWithEthers(
   params: EthersInitializerParams,
-): Promise<Result<Permit | undefined>> {
-  const result = await getEthersAbstractProviders(params);
-  if (!result.success) {
-    return ResultErr(result.error);
-  }
+): Promise<Permit | undefined> {
+  const { provider, signer } = await getEthersAbstractProviders(params);
 
   return initialize({
-    provider: result.data.provider!,
-    signer: result.data.signer!,
+    provider,
+    signer,
     ...params,
   });
 }
@@ -115,7 +110,7 @@ async function encrypt<T extends any[]>(
   setState: (state: EncryptStep) => void,
   item: [...T],
   securityZone = 0,
-): Promise<Result<[...Encrypted_Inputs<T>]>> {
+): Promise<[...Encrypted_Inputs<T>]> {
   const state = _sdkStore.getState();
   if (state.isTestnet) {
     return mockEncrypt(setState, item, securityZone);
@@ -125,12 +120,9 @@ async function encrypt<T extends any[]>(
 
   const keysResult = encryptGetKeys();
 
-  if (!keysResult.success) return ResultErr(`encrypt :: ${keysResult.error}`);
-  const { fhePublicKey, crs, verifierUrl, account, chainId } = keysResult.data;
+  const { fhePublicKey, crs, verifierUrl, account, chainId } = keysResult;
 
   const encryptableItems = encryptExtract(item);
-
-  console.log("encryptableItems", encryptableItems);
 
   setState(EncryptStep.Pack);
 
@@ -151,7 +143,7 @@ async function encrypt<T extends any[]>(
 
   setState(EncryptStep.Verify);
 
-  const zkVerifyRes = await zkVerify(
+  const verifyResults = await zkVerify(
     verifierUrl,
     proved,
     account,
@@ -159,12 +151,7 @@ async function encrypt<T extends any[]>(
     chainId,
   );
 
-  if (!zkVerifyRes.success)
-    return ResultErr(
-      `encrypt :: ZK proof verification failed - ${zkVerifyRes.error}`,
-    );
-
-  const inItems: CoFheInItem[] = zkVerifyRes.data.map(
+  const inItems: CoFheInItem[] = verifyResults.map(
     ({ ct_hash, signature }, index) => ({
       ctHash: BigInt(ct_hash),
       securityZone,
@@ -173,37 +160,38 @@ async function encrypt<T extends any[]>(
     }),
   );
 
-  console.log("inItems", inItems);
-
   setState(EncryptStep.Replace);
 
   const [preparedInputItems, remainingInItems] = encryptReplace(item, inItems);
 
   if (remainingInItems.length !== 0)
-    return ResultErr(
-      "encrypt :: some encrypted inputs remaining after replacement",
-    );
+    throw new CofhejsError({
+      code: CofhejsErrorCode.EncryptRemainingInItems,
+      message: "Some encrypted inputs remaining after replacement",
+    });
 
   setState(EncryptStep.Done);
 
-  return ResultOk(preparedInputItems);
+  return preparedInputItems;
 }
 
 export const cofhejs = {
   store: _sdkStore,
-  initialize,
-  initializeWithViem,
-  initializeWithEthers,
+  initialize: wrapFunctionAsync(initialize),
+  initializeWithViem: wrapFunctionAsync(initializeWithViem),
+  initializeWithEthers: wrapFunctionAsync(initializeWithEthers),
 
-  createPermit,
-  importPermit,
-  selectActivePermit,
-  getPermit,
-  getPermission,
-  getAllPermits,
+  createPermit: wrapFunctionAsync(createPermit),
+  importPermit: wrapFunctionAsync(importPermit),
+  selectActivePermit: wrapFunction(selectActivePermit),
+  getPermit: wrapFunction(getPermit),
+  getPermission: wrapFunction(getPermission) as (
+    hash?: string,
+  ) => Result<Permission>,
+  getAllPermits: wrapFunction(getAllPermits),
 
-  encrypt,
+  encrypt: wrapFunctionAsync(encrypt),
 
-  unseal,
-  decrypt,
+  unseal: wrapFunctionAsync(unseal),
+  decrypt: wrapFunctionAsync(decrypt),
 };

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,16 +1,65 @@
-export enum CofhejsErrorCodes {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export enum CofhejsErrorCode {
   InternalError = "INTERNAL_ERROR",
-  InvalidInput = "INVALID_INPUT",
-  InvalidOutput = "INVALID_OUTPUT",
-  InvalidState = "INVALID_STATE",
-  InvalidOperation = "INVALID_OPERATION",
+  UnknownEnvironment = "UNKNOWN_ENVIRONMENT",
+  InitTfheFailed = "INIT_TFHE_FAILED",
+  InitViemFailed = "INIT_VIEM_FAILED",
+  InitEthersFailed = "INIT_ETHERS_FAILED",
+  NotInitialized = "NOT_INITIALIZED",
+  MissingProviderParam = "MISSING_PROVIDER_PARAM",
+  MissingSecurityZonesParam = "MISSING_SECURITY_ZONES_PARAM",
+  InvalidPermitData = "INVALID_PERMIT_DATA",
+  InvalidPermitDomain = "INVALID_PERMIT_DOMAIN",
+  PermitNotFound = "PERMIT_NOT_FOUND",
+  AccountUninitialized = "ACCOUNT_UNINITIALIZED",
+  ChainIdUninitialized = "CHAIN_ID_UNINITIALIZED",
+  FheKeyNotFound = "FHE_KEY_NOT_FOUND",
+  CrsNotFound = "CRS_NOT_FOUND",
+  ProviderNotInitialized = "PROVIDER_NOT_INITIALIZED",
+  SignerNotInitialized = "SIGNER_NOT_INITIALIZED",
+  SealOutputFailed = "SEAL_OUTPUT_FAILED",
+  SealOutputReturnedNull = "SEAL_OUTPUT_RETURNED_NULL",
+  InvalidUtype = "INVALID_UTYPE",
+  DecryptFailed = "DECRYPT_FAILED",
+  DecryptReturnedNull = "DECRYPT_RETURNED_NULL",
+  ZkVerifyInsertPackedCtHashesFailed = "ZK_VERIFY_INSERT_PACKED_CT_HASHES_FAILED",
+  ZkVerifySignFailed = "ZK_VERIFY_SIGN_FAILED",
+  ZkVerifyFailed = "ZK_VERIFY_FAILED",
+  EncryptRemainingInItems = "ENCRYPT_REMAINING_IN_ITEMS",
 }
 
-export type CofhejsError = {
-  code: CofhejsErrorCodes;
-  message: string;
-  cause?: Error;
-};
+export class CofhejsError extends Error {
+  public readonly code: CofhejsErrorCode;
+  public readonly cause?: Error;
+
+  constructor({
+    code,
+    message,
+    cause,
+  }: {
+    code: CofhejsErrorCode;
+    message: string;
+    cause?: Error;
+  }) {
+    super(message);
+    this.name = "CofhejsError";
+    this.code = code;
+    this.cause = cause;
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, CofhejsError);
+    }
+  }
+
+  serialize(): string {
+    return JSON.stringify({
+      code: this.code,
+      message: this.message,
+      cause: this.cause,
+    });
+  }
+}
 
 export type Result<T> =
   | { success: true; data: T; error: null }
@@ -29,36 +78,69 @@ export const ResultOk = <T>(data: T): Result<T> => ({
 });
 
 export const isCofhejsError = (error: unknown): error is CofhejsError => {
-  return typeof error === "object" && error !== null && "code" in error;
+  if (error instanceof CofhejsError) return true;
+  return false;
 };
 
 export const ResultErrOrInternal = <T>(error: unknown): Result<T> => {
   if (isCofhejsError(error)) {
     return ResultErr(error);
   }
-  return ResultErr({
-    code: CofhejsErrorCodes.InternalError,
-    message: "An internal error occurred",
+  return ResultErr(
+    new CofhejsError({
+      code: CofhejsErrorCode.InternalError,
+      message: "An internal error occurred",
+      cause: error instanceof Error ? error : undefined,
+    }),
+  );
+};
+
+export function wrapFunction<Args extends any[], R>(
+  fn: (...args: Args) => R,
+): (...args: Args) => Result<R> {
+  return (...args: Args) => {
+    try {
+      return ResultOk(fn(...args));
+    } catch (err) {
+      return ResultErrOrInternal(err);
+    }
+  };
+}
+
+export function wrapFunctionAsync<Args extends any[], R>(
+  fn: (...args: Args) => Promise<R>,
+): (...args: Args) => Promise<Result<R>> {
+  return async (...args: Args) => {
+    try {
+      const result = await fn(...args);
+      return ResultOk(result);
+    } catch (error) {
+      return ResultErrOrInternal(error);
+    }
+  };
+}
+
+export const ResultHttpError = (
+  error: unknown,
+  url: string,
+  status?: number,
+): CofhejsError => {
+  if (error instanceof CofhejsError) return error;
+
+  const message = status
+    ? `HTTP error ${status} from ${url}`
+    : `HTTP request failed for ${url}`;
+
+  return new CofhejsError({
+    code: CofhejsErrorCode.InternalError,
+    message,
     cause: error instanceof Error ? error : undefined,
   });
 };
 
-export const wrapResult = <T>(fn: () => T): Result<T> => {
-  try {
-    const result = fn();
-    return ResultOk(result);
-  } catch (error) {
-    return ResultErrOrInternal<T>(error);
-  }
-};
-
-export const wrapResultAsync = async <T>(
-  fn: () => Promise<T>,
-): Promise<Result<T>> => {
-  try {
-    const result = await fn();
-    return ResultOk(result);
-  } catch (error) {
-    return ResultErrOrInternal<T>(error);
-  }
+export const ResultValidationError = (message: string): CofhejsError => {
+  return new CofhejsError({
+    code: CofhejsErrorCode.InvalidPermitData,
+    message,
+  });
 };

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,15 +1,64 @@
-export type Result<T, E = string> =
-  | { success: true; data: T; error: null }
-  | { success: false; data: null; error: E };
+export enum CofhejsErrorCodes {
+  InternalError = "INTERNAL_ERROR",
+  InvalidInput = "INVALID_INPUT",
+  InvalidOutput = "INVALID_OUTPUT",
+  InvalidState = "INVALID_STATE",
+  InvalidOperation = "INVALID_OPERATION",
+}
 
-export const ResultErr = <T, E>(error: E): Result<T, E> => ({
+export type CofhejsError = {
+  code: CofhejsErrorCodes;
+  message: string;
+  cause?: Error;
+};
+
+export type Result<T> =
+  | { success: true; data: T; error: null }
+  | { success: false; data: null; error: CofhejsError };
+
+export const ResultErr = <T>(error: CofhejsError): Result<T> => ({
   success: false,
   data: null,
   error,
 });
 
-export const ResultOk = <T, E>(data: T): Result<T, E> => ({
+export const ResultOk = <T>(data: T): Result<T> => ({
   success: true,
   data,
   error: null,
 });
+
+export const isCofhejsError = (error: unknown): error is CofhejsError => {
+  return typeof error === "object" && error !== null && "code" in error;
+};
+
+export const ResultErrOrInternal = <T>(error: unknown): Result<T> => {
+  if (isCofhejsError(error)) {
+    return ResultErr(error);
+  }
+  return ResultErr({
+    code: CofhejsErrorCodes.InternalError,
+    message: "An internal error occurred",
+    cause: error instanceof Error ? error : undefined,
+  });
+};
+
+export const wrapResult = <T>(fn: () => T): Result<T> => {
+  try {
+    const result = fn();
+    return ResultOk(result);
+  } catch (error) {
+    return ResultErrOrInternal<T>(error);
+  }
+};
+
+export const wrapResultAsync = async <T>(
+  fn: () => Promise<T>,
+): Promise<Result<T>> => {
+  try {
+    const result = await fn();
+    return ResultOk(result);
+  } catch (error) {
+    return ResultErrOrInternal<T>(error);
+  }
+};

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,4 +1,4 @@
-import { Environment, Result, ResultErr, ResultOk } from "../types";
+import { CofhejsError, CofhejsErrorCode, Environment } from "../types";
 
 /**
  * Applies environment-specific default values to initialization parameters
@@ -10,7 +10,7 @@ export function applyEnvironmentDefaults<
     verifierUrl?: string;
     thresholdNetworkUrl?: string;
   },
->(params: T): Result<T> {
+>(params: T): T {
   // Create a copy of the original params to avoid modifying the input
   const result = { ...params };
 
@@ -25,7 +25,7 @@ export function applyEnvironmentDefaults<
         "When environment is not specified, coFheUrl, verifierUrl, and thresholdNetworkUrl must be provided",
       );
     }
-    return ResultOk(result);
+    return result;
   }
 
   switch (params.environment) {
@@ -61,8 +61,11 @@ export function applyEnvironmentDefaults<
         "http://fullstack.tn-testnets.fhenix.zone:3000";
       break;
     default:
-      return ResultErr(`Unknown environment: ${params.environment}`);
+      throw new CofhejsError({
+        code: CofhejsErrorCode.UnknownEnvironment,
+        message: `Unknown environment: ${params.environment}`,
+      });
   }
 
-  return ResultOk(result);
+  return result;
 }

--- a/src/web/zkPoK.ts
+++ b/src/web/zkPoK.ts
@@ -21,11 +21,10 @@ import {
   toHexString,
 } from "../core/utils/utils";
 import {
+  CofhejsError,
+  CofhejsErrorCode,
   EncryptableItem,
   FheTypes,
-  Result,
-  ResultErr,
-  ResultOk,
   VerifyResult,
   VerifyResultRaw,
 } from "../types";
@@ -125,7 +124,7 @@ export const zkVerify = async (
   address: string,
   securityZone: number,
   chainId: string,
-): Promise<Result<VerifyResult[]>> => {
+): Promise<VerifyResult[]> => {
   // send this to verifier
   const list_bytes = compactList.serialize();
 
@@ -147,7 +146,6 @@ export const zkVerify = async (
   // Send request to verification server
   try {
     const response = await fetch(`${verifierUrl}/verify`, {
-      //:3001
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -158,32 +156,33 @@ export const zkVerify = async (
     if (!response.ok) {
       // Get the response body as text for better error details
       const errorBody = await response.text();
-      console.log("Response status:", response.status);
-      console.log("Response headers:", Object.fromEntries(response.headers));
-      console.log("Response body:", errorBody);
-      return ResultErr(
-        `HTTP error! status: ${response.status}, body: ${errorBody}`,
-      );
+      throw new CofhejsError({
+        code: CofhejsErrorCode.ZkVerifyFailed,
+        message: `HTTP error! ZK proof verification failed - ${errorBody}`,
+      });
     }
 
     const json: { status: string; data: VerifyResultRaw[]; error: string } =
       await response.json();
 
-    if (json.status === "success") {
-      return ResultOk(
-        json.data.map(({ ct_hash, signature, recid }) => {
-          return {
-            ct_hash,
-            signature: concatSigRecid(signature, recid),
-          };
-        }),
-      );
-    } else {
-      return ResultErr(json.error);
+    if (json.status !== "success") {
+      throw new CofhejsError({
+        code: CofhejsErrorCode.ZkVerifyFailed,
+        message: `ZK proof verification response malformed - ${json.error}`,
+      });
     }
+
+    return json.data.map(({ ct_hash, signature, recid }) => {
+      return {
+        ct_hash,
+        signature: concatSigRecid(signature, recid),
+      };
+    });
   } catch (e) {
-    const message = e instanceof Error ? e.message : `Error: ${e}`;
-    console.error(message);
-    return ResultErr(message);
+    throw new CofhejsError({
+      code: CofhejsErrorCode.ZkVerifyFailed,
+      message: `ZK proof verification failed`,
+      cause: e instanceof Error ? e : undefined,
+    });
   }
 };

--- a/test/arb-sepolia.test.ts
+++ b/test/arb-sepolia.test.ts
@@ -30,7 +30,7 @@ import {
 import { cofhejs, createTfhePublicKey, Permit } from "../src/node";
 import { _permitStore, permitStore } from "../src/core/permit/store";
 
-describe.skip("Arbitrum Sepolia Tests", () => {
+describe("Arbitrum Sepolia Tests", () => {
   let bobPublicKey: string;
   let bobProvider: MockProvider;
   let bobSigner: MockSigner;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { ethers } from "ethers";
-import { AbstractProvider, AbstractSigner, Result } from "../src/types";
+import {
+  AbstractProvider,
+  AbstractSigner,
+  Result,
+  CofhejsError,
+  CofhejsErrorCode,
+} from "../src/types";
 import { expect } from "vitest";
-
-// Initialize genesis accounts
-const mnemonics = [
-  "grant rice replace explain federal release fix clever romance raise often wild taxi quarter soccer fiber love must tape steak together observe swap guitar", // account a
-  "jelly shadow frog dirt dragon use armed praise universe win jungle close inmate rain oil canvas beauty pioneer chef soccer icon dizzy thunder meadow", // account b
-  "chair love bleak wonder skirt permit say assist aunt credit roast size obtain minute throw sand usual age smart exact enough room shadow charge", // account c
-];
 
 // Anvil account 3 - address 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
 export const BobWallet = new ethers.Wallet(
@@ -125,15 +124,45 @@ export class MockProvider implements AbstractProvider {
 }
 
 export const expectResultSuccess = <T>(result: Result<T>): T => {
-  expect(result.error).toEqual(null);
-  expect(result.data).not.toEqual(null);
+  expect(result.error).toBe(null);
+  expect(result.success).toBe(true);
+  expect(result.data).not.toBe(null);
   return result.data as T;
 };
 
 export const expectResultError = <T>(
   result: Result<T>,
-  error: string,
+  errorCode?: CofhejsErrorCode,
+  errorMessage?: string,
 ): void => {
-  expect(result.error).toEqual(error);
-  expect(result.data).toEqual(null);
+  expect(result.success).toBe(false);
+  expect(result.data).toBe(null);
+  expect(result.error).not.toBe(null);
+  const error = result.error as CofhejsError;
+  expect(error).toBeInstanceOf(CofhejsError);
+  if (errorCode) {
+    expect(error.code).toBe(errorCode);
+  }
+  if (errorMessage) {
+    expect(error.message).toBe(errorMessage);
+  }
+};
+
+export const expectResultErrorCode = <T>(
+  result: Result<T>,
+  errorCode: CofhejsErrorCode,
+): void => {
+  expectResultError(result, errorCode);
+};
+
+export const expectResultErrorMessage = <T>(
+  result: Result<T>,
+  errorMessage: string,
+): void => {
+  expect(result.success).toBe(false);
+  expect(result.data).toBe(null);
+  expect(result.error).not.toBe(null);
+  const error = result.error as CofhejsError;
+  expect(error).toBeInstanceOf(CofhejsError);
+  expect(error.message).toBe(errorMessage);
 };


### PR DESCRIPTION
The result type needed a refactor. It is currently returning error strings which will be difficult to parse in the frontend and are not very descriptive. This PR introduces the CofhejsErrorCode and the CofhejsError class. These are returned as part of the Error response rather than just a string.

This PR also moves the `Result` out of internal usage and instead puts it where the final cofhejs exports happen (web/sdk.ts and node/sdk.ts). Exported functions are wrapped in `wrapFunction` or `wrapAsyncFunction` which preserves the typing but wraps the output in a Result type .