### PR TITLE
Fix permit selection by chainId

### DIFF
--- a/src/core/sdk/index.ts
+++ b/src/core/sdk/index.ts
@@ -156,8 +156,8 @@ export const createPermit = async (
 
   const permit = await Permit.createAndSign(optionsWithDefaults, state.signer);
 
-  permitStore.setPermit(state.account!, permit);
-  permitStore.setActivePermitHash(state.account!, permit.getHash());
+  permitStore.setPermit(state.chainId!, state.account!, permit);
+  permitStore.setActivePermitHash(state.chainId!, state.account!, permit.getHash());
 
   return permit;
 };
@@ -220,8 +220,8 @@ export const importPermit = async (
     });
   }
 
-  permitStore.setPermit(state.account!, permit);
-  permitStore.setActivePermitHash(state.account!, permit.getHash());
+  permitStore.setPermit(state.chainId!, state.account!, permit);
+  permitStore.setActivePermitHash(state.chainId!, state.account!, permit.getHash());
 
   return permit;
 };
@@ -238,14 +238,14 @@ export const selectActivePermit = (hash: string): Permit => {
 
   _checkInitialized(state);
 
-  const permit = permitStore.getPermit(state.account, hash);
+  const permit = permitStore.getPermit(state.chainId, state.account, hash);
   if (permit == null)
     throw new CofhejsError({
       code: CofhejsErrorCode.PermitNotFound,
       message: `Permit with hash <${hash}> not found`,
     });
 
-  permitStore.setActivePermitHash(state.account!, permit.getHash());
+  permitStore.setActivePermitHash(state.chainId!, state.account!, permit.getHash());
 
   return permit;
 };
@@ -263,7 +263,7 @@ export const getPermit = (hash?: string): Permit => {
   _checkInitialized(state);
 
   if (hash == null) {
-    const permit = permitStore.getActivePermit(state.account);
+    const permit = permitStore.getActivePermit(state.chainId, state.account);
     if (permit == null)
       throw new CofhejsError({
         code: CofhejsErrorCode.PermitNotFound,
@@ -273,7 +273,7 @@ export const getPermit = (hash?: string): Permit => {
     return permit;
   }
 
-  const permit = permitStore.getPermit(state.account, hash);
+  const permit = permitStore.getPermit(state.chainId, state.account, hash);
   if (permit == null)
     throw new CofhejsError({
       code: CofhejsErrorCode.PermitNotFound,
@@ -307,7 +307,7 @@ export const getAllPermits = (): Record<string, Permit> => {
 
   _checkInitialized(state);
 
-  return permitStore.getPermits(state.account);
+  return permitStore.getPermits(state.chainId, state.account);
 };
 
 // Encrypt (Steps)
@@ -453,7 +453,11 @@ export async function unseal<U extends FheTypes>(
 
   const resolvedAccount = account ?? _sdkStore.getState().account;
   const resolvedHash =
-    permitHash ?? permitStore.getActivePermitHash(resolvedAccount);
+    permitHash ??
+    permitStore.getActivePermitHash(
+      _sdkStore.getState().chainId,
+      resolvedAccount,
+    );
 
   if (resolvedAccount == null || resolvedHash == null) {
     throw new CofhejsError({
@@ -462,7 +466,11 @@ export async function unseal<U extends FheTypes>(
     });
   }
 
-  const permit = permitStore.getPermit(resolvedAccount, resolvedHash);
+  const permit = permitStore.getPermit(
+    _sdkStore.getState().chainId,
+    resolvedAccount,
+    resolvedHash,
+  );
   if (permit == null) {
     throw new CofhejsError({
       code: CofhejsErrorCode.PermitNotFound,
@@ -529,7 +537,11 @@ export async function decrypt<U extends FheTypes>(
 
   const resolvedAccount = account ?? _sdkStore.getState().account;
   const resolvedHash =
-    permitHash ?? permitStore.getActivePermitHash(resolvedAccount);
+    permitHash ??
+    permitStore.getActivePermitHash(
+      _sdkStore.getState().chainId,
+      resolvedAccount,
+    );
   if (resolvedAccount == null || resolvedHash == null) {
     throw new CofhejsError({
       code: CofhejsErrorCode.PermitNotFound,
@@ -537,7 +549,11 @@ export async function decrypt<U extends FheTypes>(
     });
   }
 
-  const permit = permitStore.getPermit(resolvedAccount, resolvedHash);
+  const permit = permitStore.getPermit(
+    _sdkStore.getState().chainId,
+    resolvedAccount,
+    resolvedHash,
+  );
   if (permit == null) {
     throw new CofhejsError({
       code: CofhejsErrorCode.PermitNotFound,

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -36,6 +36,7 @@ describe("Sdk Tests", () => {
   let bobProvider: MockProvider;
   let bobSigner: MockSigner;
   let bobAddress: string;
+  let bobChainId: string;
 
   let adaPublicKey: string;
   let adaProvider: MockProvider;
@@ -69,6 +70,7 @@ describe("Sdk Tests", () => {
   beforeAll(async () => {
     bobPublicKey = await createTfhePublicKey();
     bobProvider = new MockProvider(bobPublicKey, BobWallet, rpcUrl, 420105n);
+    bobChainId = bobProvider.chainId.toString();
     bobSigner = await bobProvider.getSigner();
     bobAddress = await bobSigner.getAddress();
 
@@ -283,8 +285,8 @@ describe("Sdk Tests", () => {
 
     // Keys store
     expect(dumped["cofhejs-keys"]["state"]).to.have.keys(["fhe", "crs"]);
-    expect(dumped["cofhejs-keys"]["state"]["fhe"]).to.have.keys(["420105"]);
-    expect(dumped["cofhejs-keys"]["state"]["crs"]).to.have.keys(["420105"]);
+    expect(dumped["cofhejs-keys"]["state"]["fhe"]).to.have.keys([bobChainId]);
+    expect(dumped["cofhejs-keys"]["state"]["crs"]).to.have.keys([bobChainId]);
 
     // Permits store
 
@@ -295,12 +297,14 @@ describe("Sdk Tests", () => {
 
     // Permits
     const bobsPermitsDumped =
-      dumped["cofhejs-permits"]["state"]["permits"][bobAddress];
+      dumped["cofhejs-permits"]["state"]["permits"][bobChainId][bobAddress];
     expect(bobsPermitsDumped).to.have.keys(permit1?.getHash() ?? "permit1Hash");
 
     // ActivePermit
     expect(
-      dumped["cofhejs-permits"]["state"]["activePermitHash"][bobAddress],
+      dumped["cofhejs-permits"]["state"]["activePermitHash"][bobChainId][
+        bobAddress
+      ],
     ).toEqual(permit1?.getHash());
   });
   it("createPermit", async () => {
@@ -323,7 +327,9 @@ describe("Sdk Tests", () => {
     // Permit established in store
 
     const storePermitSerialized =
-      permitStore.store.getState().permits[bobAddress]?.[permit.getHash()];
+      permitStore.store.getState().permits[bobChainId][bobAddress]?.[
+        permit.getHash()
+      ];
     expect(storePermitSerialized).to.not.be.null;
 
     const storePermit = Permit.deserialize(storePermitSerialized!);
@@ -332,7 +338,7 @@ describe("Sdk Tests", () => {
     // Is active permit
 
     const storeActivePermitHash =
-      permitStore.store.getState().activePermitHash[bobAddress];
+      permitStore.store.getState().activePermitHash[bobChainId][bobAddress];
     expect(storeActivePermitHash).toEqual(permit.getHash());
 
     // Creating new permit
@@ -345,7 +351,7 @@ describe("Sdk Tests", () => {
     );
 
     const storeActivePermitHash2 =
-      permitStore.store.getState().activePermitHash[bobAddress];
+      permitStore.store.getState().activePermitHash[bobChainId][bobAddress];
     expect(storeActivePermitHash2).toEqual(permit2.getHash());
   });
 


### PR DESCRIPTION
## Summary
- index permits by chainId in permit store
- migrate legacy permit storage
- update SDK to use chain-aware permit functions
- adjust tests for new permit store layout

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*