### PR TITLE
Add mock-config with decrypt delay and zkvSigner

### DIFF
--- a/src/core/sdk/initializers.ts
+++ b/src/core/sdk/initializers.ts
@@ -12,20 +12,84 @@ import { unwrapCallResult } from "../utils";
 type InitializerReturn = Promise<{
   signer: AbstractSigner;
   provider: AbstractProvider;
+  zkvSigner?: AbstractSigner;
 }>;
 
 // Shared initializers
 
 export type ViemInitializerParams = Omit<
   InitializationParams,
-  "tfhePublicKeySerializer" | "compactPkeCrsSerializer" | "provider" | "signer"
+  | "tfhePublicKeySerializer"
+  | "compactPkeCrsSerializer"
+  | "provider"
+  | "signer"
+  | "mockConfig"
 > & {
   ignoreErrors?: boolean;
   generatePermit?: boolean;
   environment?: Environment;
   viemClient: any; // Replace 'any' with the actual Viem client type
   viemWalletClient?: any; // Replace 'any' with the actual Viem wallet client type
+  mockConfig?: {
+    decryptDelay?: number;
+    zkvSigner?: any;
+  };
 };
+
+export function viemProviderSignerTransformer(
+  viemClient: any,
+  viemWalletClient: any,
+) {
+  const provider: AbstractProvider = {
+    getChainId: async () => {
+      return await viemClient.getChainId();
+    },
+    call: async (transaction: any) => {
+      return unwrapCallResult(
+        await viemClient.call({
+          ...transaction,
+        }),
+      );
+    },
+    send: async (method: string, params: any[]) => {
+      return await viemClient.send(method, params);
+    },
+  };
+
+  // Create signer adapter if wallet client is provided
+  const signer: AbstractSigner = {
+    getAddress: async (): Promise<string> => {
+      return viemWalletClient
+        .getAddresses()
+        .then((addresses: string) => addresses[0]);
+    },
+    signTypedData: async (
+      domain: any,
+      types: any,
+      value: any,
+    ): Promise<string> => {
+      return await viemWalletClient.signTypedData({
+        domain,
+        types,
+        primaryType: Object.keys(types)[0], // Usually the primary type is the first key in types
+        message: value,
+      });
+    },
+    provider: provider,
+    sendTransaction: async (tx: {
+      to: string;
+      data: string;
+    }): Promise<string> => {
+      return await viemWalletClient.sendTransaction(tx);
+    },
+    // Add other signer methods as needed
+  };
+
+  return {
+    provider,
+    signer,
+  };
+}
 
 /**
  * Initializes the SDK with a Viem client
@@ -52,53 +116,21 @@ export async function getViemAbstractProviders(
     // Extract Viem-specific parameters
     const { viemClient, viemWalletClient } = params;
 
-    const provider: AbstractProvider = {
-      getChainId: async () => {
-        return await viemClient.getChainId();
-      },
-      call: async (transaction: any) => {
-        return unwrapCallResult(await viemClient.call({
-          ...transaction,
-        }));
-      },
-      send: async (method: string, params: any[]) => {
-        return await viemClient.send(method, params);
-      },
-    };
+    const { provider, signer } = viemProviderSignerTransformer(
+      viemClient,
+      viemWalletClient,
+    );
 
-    // Create signer adapter if wallet client is provided
-    const signer: AbstractSigner = {
-      getAddress: async (): Promise<string> => {
-        return viemWalletClient
-          .getAddresses()
-          .then((addresses: string) => addresses[0]);
-      },
-      signTypedData: async (
-        domain: any,
-        types: any,
-        value: any,
-      ): Promise<string> => {
-        return await viemWalletClient.signTypedData({
-          domain,
-          types,
-          primaryType: Object.keys(types)[0], // Usually the primary type is the first key in types
-          message: value,
-        });
-      },
-      provider: provider,
-      sendTransaction: async (tx: {
-        to: string;
-        data: string;
-      }): Promise<string> => {
-        return await viemWalletClient.sendTransaction(tx);
-      },
-      // Add other signer methods as needed
-    };
+    const { signer: zkvSigner } = viemProviderSignerTransformer(
+      viemClient,
+      params.mockConfig?.zkvSigner,
+    );
 
     // Call the original initialize function with adapted parameters
     return {
       signer,
       provider,
+      zkvSigner,
     };
   } catch (error) {
     throw new CofhejsError({
@@ -117,8 +149,63 @@ export type EthersInitializerParams = Omit<
   ethersProvider: any; // Ethers provider (e.g., Web3Provider connected to window.ethereum)
   ethersSigner?: any; // Ethers signer (usually provider.getSigner())
   environment?: Environment;
-
+  mockConfig?: {
+    decryptDelay?: number;
+    zkvSigner?: any;
+  };
 };
+
+function ethersProviderSignerTransformer(
+  ethersProvider: any,
+  ethersSigner: any,
+) {
+  const provider: AbstractProvider = {
+    getChainId: async () => {
+      return (await ethersProvider.getNetwork()).chainId.toString();
+    },
+    call: async (transaction: any) => {
+      // Pass through to the original provider's call method
+      return unwrapCallResult(await ethersProvider.call(transaction));
+    },
+    send: async (method: string, params: any[]) => {
+      return await ethersProvider.send(method, params);
+    },
+  };
+
+  const signer: AbstractSigner = {
+    getAddress: async () => {
+      return await ethersSigner.getAddress();
+    },
+    signTypedData: async (domain: any, types: any, value: any) => {
+      // Ethers v5 uses _signTypedData
+      if (typeof ethersSigner._signTypedData === "function") {
+        return await ethersSigner._signTypedData(domain, types, value);
+      }
+      // Ethers v6 uses signTypedData
+      else if (typeof ethersSigner.signTypedData === "function") {
+        return await ethersSigner.signTypedData(domain, types, value);
+      }
+      // Fallback for other versions or implementations
+      else {
+        throw new Error(
+          "Ethers signer does not support signTypedData or _signTypedData",
+        );
+      }
+    },
+    provider: provider,
+    sendTransaction: async (tx: {
+      to: string;
+      data: string;
+    }): Promise<string> => {
+      return await ethersSigner.sendTransaction(tx);
+    },
+  };
+
+  return {
+    provider,
+    signer,
+  };
+}
 
 /**
  * Initializes the SDK with ethers.js provider and signer
@@ -131,51 +218,20 @@ export async function getEthersAbstractProviders(
   try {
     const { ethersProvider, ethersSigner } = params;
 
-    const provider: AbstractProvider = {
-      getChainId: async () => {
-        return (await ethersProvider.getNetwork()).chainId.toString();
-      },
-      call: async (transaction: any) => {
-        // Pass through to the original provider's call method
-        return unwrapCallResult(await ethersProvider.call(transaction));
-      },
-      send: async (method: string, params: any[]) => {
-        return await ethersProvider.send(method, params);
-      },
-    };
+    const { provider, signer } = ethersProviderSignerTransformer(
+      ethersProvider,
+      ethersSigner,
+    );
 
-    const signer: AbstractSigner = {
-      getAddress: async () => {
-        return await ethersSigner.getAddress();
-      },
-      signTypedData: async (domain: any, types: any, value: any) => {
-        // Ethers v5 uses _signTypedData
-        if (typeof ethersSigner._signTypedData === "function") {
-          return await ethersSigner._signTypedData(domain, types, value);
-        }
-        // Ethers v6 uses signTypedData
-        else if (typeof ethersSigner.signTypedData === "function") {
-          return await ethersSigner.signTypedData(domain, types, value);
-        }
-        // Fallback for other versions or implementations
-        else {
-          throw new Error(
-            "Ethers signer does not support signTypedData or _signTypedData",
-          );
-        }
-      },
-      provider: provider,
-      sendTransaction: async (tx: {
-        to: string;
-        data: string;
-      }): Promise<string> => {
-        return await ethersSigner.sendTransaction(tx);
-      },
-    };
+    const { signer: zkvSigner } = viemProviderSignerTransformer(
+      ethersProvider,
+      params.mockConfig?.zkvSigner,
+    );
 
     return {
       signer,
       provider,
+      zkvSigner,
     };
   } catch (error) {
     throw new CofhejsError({

--- a/src/core/sdk/store.ts
+++ b/src/core/sdk/store.ts
@@ -157,9 +157,13 @@ export type SdkStore = SdkStoreProviderInitialization &
     verifierUrl: string | undefined;
     thresholdNetworkUrl: string | undefined;
 
-    // Not required, used in mocks to send the insertPackedCtHashes tx
-    // If not provided, the connected signer is used instead (will require wallet signature in frontend if on mocks)
-    zkvSigner: AbstractSigner;
+    mockConfig: {
+      // Delay in milliseconds to wait before decrypting the output
+      decryptDelay: number;
+      // Not required, used in mocks to send the insertPackedCtHashes tx
+      // If not provided, the connected signer is used instead (will require wallet signature in frontend if on mocks)
+      zkvSigner: AbstractSigner | undefined;
+    };
   };
 
 export const _sdkStore = createStore<SdkStore>(
@@ -181,7 +185,10 @@ export const _sdkStore = createStore<SdkStore>(
       signer: undefined as never,
       account: undefined as never,
 
-      zkvSigner: undefined as never,
+      mockConfig: {
+        decryptDelay: 0,
+        zkvSigner: undefined,
+      },
     }) as SdkStore,
 );
 
@@ -237,7 +244,7 @@ export const _store_initialize = async (params: InitializationParams) => {
     coFheUrl,
     verifierUrl,
     thresholdNetworkUrl,
-    zkvSigner,
+    mockConfig,
   } = params;
 
   _sdkStore.setState({
@@ -246,7 +253,10 @@ export const _store_initialize = async (params: InitializationParams) => {
     coFheUrl,
     verifierUrl,
     thresholdNetworkUrl,
-    zkvSigner,
+    mockConfig: {
+      decryptDelay: mockConfig?.decryptDelay ?? 0,
+      zkvSigner: mockConfig?.zkvSigner,
+    },
   });
 
   // PROVIDER

--- a/src/core/sdk/testnet.ts
+++ b/src/core/sdk/testnet.ts
@@ -63,13 +63,19 @@ export async function checkIsTestnet(
 }
 
 async function mockZkVerifySign(
-  zkvSigner: AbstractSigner | undefined,
+  mockConfig: {
+    decryptDelay: number;
+    zkvSigner: AbstractSigner | undefined;
+  },
   signer: AbstractSigner,
   provider: AbstractProvider,
   user: string,
   items: EncryptableItem[],
   securityZone: number,
 ): Promise<VerifyResult[]> {
+  // Delay before decrypting the output
+  await sleep(mockConfig.decryptDelay);
+
   // Create array to store results
   const results = [];
 
@@ -119,7 +125,7 @@ async function mockZkVerifySign(
     );
 
     // Call insertPackedCtHashes
-    await (zkvSigner ?? signer).sendTransaction({
+    await (mockConfig.zkvSigner ?? signer).sendTransaction({
       to: MockZkVerifierAddress,
       data: insertPackedCtHashesCallData,
     });
@@ -217,7 +223,7 @@ export async function mockEncrypt<T extends any[]>(
   await sleep(500);
 
   const signedResults = await mockZkVerifySign(
-    state.zkvSigner,
+    state.mockConfig,
     state.signer,
     state.provider,
     state.account,

--- a/src/node/sdk.ts
+++ b/src/node/sdk.ts
@@ -88,24 +88,34 @@ export const initialize = async (
 async function initializeWithViem(
   params: ViemInitializerParams,
 ): Promise<Permit | undefined> {
-  const { provider, signer } = await getViemAbstractProviders(params);
+  const { provider, signer, zkvSigner } =
+    await getViemAbstractProviders(params);
 
   return initialize({
     provider,
     signer,
     ...params,
+    mockConfig: {
+      decryptDelay: params.mockConfig?.decryptDelay ?? 0,
+      zkvSigner,
+    },
   });
 }
 
 async function initializeWithEthers(
   params: EthersInitializerParams,
 ): Promise<Permit | undefined> {
-  const { provider, signer } = await getEthersAbstractProviders(params);
+  const { provider, signer, zkvSigner } =
+    await getEthersAbstractProviders(params);
 
   return initialize({
     provider,
     signer,
     ...params,
+    mockConfig: {
+      decryptDelay: params.mockConfig?.decryptDelay ?? 0,
+      zkvSigner,
+    },
   });
 }
 

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -27,5 +27,8 @@ export type InitializationParams = {
   thresholdNetworkUrl?: string;
   tfhePublicKeySerializer: (buff: Uint8Array) => void;
   compactPkeCrsSerializer: (buff: Uint8Array) => void;
-  zkvSigner?: AbstractSigner;
+  mockConfig?: {
+    decryptDelay?: number;
+    zkvSigner?: AbstractSigner;
+  };
 };

--- a/src/web/sdk.ts
+++ b/src/web/sdk.ts
@@ -88,24 +88,34 @@ export const initialize = async (
 async function initializeWithViem(
   params: ViemInitializerParams,
 ): Promise<Permit | undefined> {
-  const { provider, signer } = await getViemAbstractProviders(params);
+  const { provider, signer, zkvSigner } =
+    await getViemAbstractProviders(params);
 
   return initialize({
     provider,
     signer,
     ...params,
+    mockConfig: {
+      decryptDelay: params.mockConfig?.decryptDelay ?? 0,
+      zkvSigner,
+    },
   });
 }
 
 async function initializeWithEthers(
   params: EthersInitializerParams,
 ): Promise<Permit | undefined> {
-  const { provider, signer } = await getEthersAbstractProviders(params);
+  const { provider, signer, zkvSigner } =
+    await getEthersAbstractProviders(params);
 
   return initialize({
     provider,
     signer,
     ...params,
+    mockConfig: {
+      decryptDelay: params.mockConfig?.decryptDelay ?? 0,
+      zkvSigner,
+    },
   });
 }
 

--- a/test/mocks.test.ts
+++ b/test/mocks.test.ts
@@ -13,7 +13,7 @@ import {
   MockSigner,
 } from "./utils";
 import { afterEach } from "vitest";
-import { ethers } from "ethers";
+import { ethers, getAddress, hexlify } from "ethers";
 import {
   Encryptable,
   CoFheInUint64,
@@ -49,7 +49,10 @@ describe("Mocks (Hardhat Node) Tests", () => {
       provider: bobProvider,
       signer: bobSigner,
       environment: "MOCK",
-      zkvSigner: bobSigner,
+      mockConfig: {
+        decryptDelay: 0,
+        zkvSigner: bobSigner,
+      },
     });
   };
   const initSdkWithAda = async () => {
@@ -57,7 +60,10 @@ describe("Mocks (Hardhat Node) Tests", () => {
       provider: adaProvider,
       signer: adaSigner,
       environment: "MOCK",
-      zkvSigner: adaSigner,
+      mockConfig: {
+        decryptDelay: 0,
+        zkvSigner: adaSigner,
+      },
     });
   };
 
@@ -293,7 +299,8 @@ describe("Mocks (Hardhat Node) Tests", () => {
     const uintValue = 937387n;
     const uintSealed = SealingKey.seal(uintValue, permit.sealingPair.publicKey);
     const uintCleartext = permit.unseal(uintSealed);
-    expect(uintCleartext).toEqual(uintValue);
+    const uintCleartextHex = `0x${uintCleartext.toString(16)}`;
+    expect(uintCleartextHex).toEqual(`0x${uintValue.toString(16)}`);
 
     // Address
     const addressValue = contractAddress;
@@ -302,6 +309,9 @@ describe("Mocks (Hardhat Node) Tests", () => {
       permit.sealingPair.publicKey,
     );
     const addressCleartext = permit.unseal(addressSealed);
-    expect(addressCleartext).toEqual(addressValue);
+    const addressCleartextHex = getAddress(
+      `0x${addressCleartext.toString(16)}`,
+    );
+    expect(addressCleartextHex).toEqual(addressValue);
   });
 });

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -57,7 +57,10 @@ describe("Sdk Tests", () => {
       provider: bobProvider,
       signer: bobSigner,
       environment: "LOCAL",
-      zkvSigner: bobSigner,
+      mockConfig: {
+        decryptDelay: 0,
+        zkvSigner: bobSigner,
+      },
     });
   };
   const initSdkWithAda = async () => {
@@ -65,7 +68,10 @@ describe("Sdk Tests", () => {
       provider: adaProvider,
       signer: adaSigner,
       environment: "LOCAL",
-      zkvSigner: adaSigner,
+      mockConfig: {
+        decryptDelay: 0,
+        zkvSigner: adaSigner,
+      },
     });
   };
 


### PR DESCRIPTION
decryptDelay is an optional number that delays the mock sealOutput to replicate the off-chain delay
zkvSigner has been added to the initializers to prevent encrypting an input variable from requiring a user signature in their wallet