### PR TITLE
[Bugfix] Ensure loaded keys are converted to Uint8Array

### DIFF
--- a/src/core/sdk/store.ts
+++ b/src/core/sdk/store.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createStore } from "zustand/vanilla";
 import { produce } from "immer";
-import { fromHexString } from "../utils/utils";
+import { ensureUint8Array, fromHexString } from "../utils/utils";
 import { PUBLIC_KEY_LENGTH_MIN } from "../utils/consts";
 import {
   AbstractProvider,
@@ -200,7 +200,8 @@ export const _store_isTestnet = () => {
 
 const _store_getFheKey = (chainId: string | undefined, securityZone = 0) => {
   if (chainId == null || securityZone == null) return undefined;
-  return _keysStore.getState().fhe[chainId]?.[securityZone];
+  const stored = _keysStore.getState().fhe[chainId]?.[securityZone];
+  return stored ? ensureUint8Array(stored) : undefined;
 };
 
 export const _store_getConnectedChainFheKey = (securityZone = 0) => {
@@ -209,12 +210,14 @@ export const _store_getConnectedChainFheKey = (securityZone = 0) => {
   if (securityZone == null) return undefined;
   if (state.chainId == null) return undefined;
 
-  return _keysStore.getState().fhe[state.chainId]?.[securityZone];
+  const stored = _keysStore.getState().fhe[state.chainId]?.[securityZone];
+  return stored ? ensureUint8Array(stored) : undefined;
 };
 
 export const _store_getCrs = (chainId: string | undefined) => {
   if (chainId == null) return undefined;
-  return _keysStore.getState().crs[chainId];
+  const stored = _keysStore.getState().crs[chainId];
+  return stored ? ensureUint8Array(stored) : undefined;
 };
 
 const getChainIdFromProvider = async (

--- a/src/core/utils/utils.ts
+++ b/src/core/utils/utils.ts
@@ -239,6 +239,8 @@ export const bigintToUint8Array = (bigNum: bigint): Uint8Array => {
 
   return byteArray;
 };
+export const ensureUint8Array = (data: Uint8Array | Object) =>
+  data instanceof Uint8Array ? data : new Uint8Array(Object.values(data));
 
 // General tooling
 


### PR DESCRIPTION
Fixes a bug where Public Key and CRS are loaded properly only fresh, when they don't exist in the local storage.