### PR TITLE
encryptInputs with improved API

### DIFF
--- a/src/core/encrypt/encryptInput.test.ts
+++ b/src/core/encrypt/encryptInput.test.ts
@@ -11,7 +11,35 @@ import {
   VerifyResult,
 } from "../../types";
 import { ZkPackProveVerify } from "./zkPackProveVerify";
-import { constructZkPoKMetadata } from "../utils/zkPoK";
+
+// Mock the functions with vitest
+const mockZkPack = vi.fn();
+const mockZkProve = vi.fn();
+const mockZkVerify = vi.fn();
+
+const packMetadata = (
+  signer: string,
+  securityZone: number,
+  chainId: string,
+) => {
+  return `${signer}-${securityZone}-${chainId}`;
+};
+const unpackMetadata = (metadata: string) => {
+  const [signer, securityZone, chainId] = metadata.split("-");
+  return { signer, securityZone: parseInt(securityZone), chainId };
+};
+const packVerifyResult = (item: EncryptableItem, metadata: string) => {
+  return {
+    ct_hash: `${item.data}`,
+    signature: metadata,
+  };
+};
+const unpackVerifyResult = (result: VerifyResult) => {
+  return {
+    ct_hash: result.ct_hash,
+    metadata: unpackMetadata(result.signature),
+  };
+};
 
 class MockZkListBuilder {
   private items: EncryptableItem[];
@@ -19,53 +47,55 @@ class MockZkListBuilder {
     this.items = items;
   }
 
-  prove(metadata: Uint8Array): MockZkProvenList {
+  prove(metadata: string): MockZkProvenList {
     return new MockZkProvenList(this.items, metadata);
   }
 }
 
-const mockZkPack = (items: EncryptableItem[]): MockZkListBuilder => {
+const mockZkPackImpl = (items: EncryptableItem[]): MockZkListBuilder => {
+  mockZkPack(items);
   return new MockZkListBuilder(items);
 };
 
 class MockZkProvenList {
   private items: EncryptableItem[];
-  private metadata: Uint8Array;
+  private metadata: string;
 
-  constructor(items: EncryptableItem[], metadata: Uint8Array) {
+  constructor(items: EncryptableItem[], metadata: string) {
     this.items = items;
     this.metadata = metadata;
   }
 
   verify(): Promise<VerifyResult[]> {
-    return Promise.resolve([
-      { ct_hash: "123456789", signature: "0xabcdef123456789" },
-    ]);
+    const verifiedItems = this.items.map((item) => {
+      return packVerifyResult(item, this.metadata);
+    });
+
+    return Promise.resolve(verifiedItems);
   }
 }
 
-const mockZkProve = (
+const mockZkProveImpl = (
   builder: MockZkListBuilder,
   address: string,
   securityZone: number,
   chainId: string,
 ): Promise<MockZkProvenList> => {
-  const metadata = constructZkPoKMetadata(
-    address,
-    securityZone,
-    parseInt(chainId),
-  );
+  mockZkProve(builder, address, securityZone, chainId);
+
+  const metadata = packMetadata(address, securityZone, chainId);
 
   return Promise.resolve(builder.prove(metadata));
 };
 
-const mockZkVerify = (
-  _verifierUrl: string,
+const mockZkVerifyImpl = (
+  verifierUrl: string,
   proved: MockZkProvenList,
-  _address: string,
-  _securityZone: number,
-  _chainId: string,
+  address: string,
+  securityZone: number,
+  chainId: string,
 ): Promise<VerifyResult[]> => {
+  mockZkVerify(verifierUrl, proved, address, securityZone, chainId);
   return Promise.resolve(proved.verify());
 };
 
@@ -75,15 +105,24 @@ describe("EncryptInputsBuilder", () => {
     sender: "0x1234567890123456789012345678901234567890",
     chainId: "1",
     zkVerifierUrl: "http://localhost:3001",
-    zk: new ZkPackProveVerify(mockZkPack, mockZkProve, mockZkVerify),
+    zk: new ZkPackProveVerify(
+      mockZkPackImpl,
+      mockZkProveImpl,
+      mockZkVerifyImpl,
+    ),
   };
   let builder: EncryptInputsBuilder<[EncryptableUint128]>;
 
   beforeEach(() => {
+    // Reset all mocks before each test
+    mockZkPack.mockClear();
+    mockZkProve.mockClear();
+    mockZkVerify.mockClear();
+
     const mockZkPackProveVerify = new ZkPackProveVerify(
-      mockZkPack,
-      mockZkProve,
-      mockZkVerify,
+      mockZkPackImpl,
+      mockZkProveImpl,
+      mockZkVerifyImpl,
     );
     defaultParams.zk = mockZkPackProveVerify;
     builder = new EncryptInputsBuilder(defaultParams);
@@ -110,34 +149,49 @@ describe("EncryptInputsBuilder", () => {
 
   describe("setSender", () => {
     it("should set sender and return builder for chaining", () => {
-      const result = builder.setSender(
-        "0x9876543210987654321098765432109876543210",
-      );
+      const sender = "0x9876543210987654321098765432109876543210";
+
+      const result = builder.setSender(sender);
+
       expect(result).toBe(builder);
+      expect(result.getSender()).toBe(sender);
     });
 
     it("should allow chaining with other methods", () => {
+      const sender = "0x1111111111111111111111111111111111111111";
+      const securityZone = 5;
+
       const result = builder
-        .setSender("0x1111111111111111111111111111111111111111")
-        .setSecurityZone(5)
+        .setSender(sender)
+        .setSecurityZone(securityZone)
         .setStepCallback(() => {});
 
       expect(result).toBe(builder);
+      expect(result.getSender()).toBe(sender);
+      expect(result.getSecurityZone()).toBe(securityZone);
     });
   });
 
   describe("setSecurityZone", () => {
     it("should set security zone and return builder for chaining", () => {
-      const result = builder.setSecurityZone(42);
+      const securityZone = 42;
+      const result = builder.setSecurityZone(securityZone);
       expect(result).toBe(builder);
+      expect(result.getSecurityZone()).toBe(securityZone);
     });
 
     it("should allow chaining with other methods", () => {
+      const sender = "0x2222222222222222222222222222222222222222";
+      const securityZone = 10;
+
       const result = builder
-        .setSecurityZone(10)
-        .setSender("0x2222222222222222222222222222222222222222");
+        .setSecurityZone(securityZone)
+        .setSender(sender)
+        .setStepCallback(() => {});
 
       expect(result).toBe(builder);
+      expect(result.getSender()).toBe(sender);
+      expect(result.getSecurityZone()).toBe(securityZone);
     });
   });
 
@@ -164,7 +218,7 @@ describe("EncryptInputsBuilder", () => {
       const result = await builder.encrypt();
 
       // Verify step callbacks were called in order
-      expect(stepCallback).toHaveBeenCalledTimes(5);
+      expect(stepCallback).toHaveBeenCalledTimes(6);
       expect(stepCallback).toHaveBeenNthCalledWith(1, EncryptStep.Extract);
       expect(stepCallback).toHaveBeenNthCalledWith(2, EncryptStep.Pack);
       expect(stepCallback).toHaveBeenNthCalledWith(3, EncryptStep.Prove);
@@ -173,22 +227,22 @@ describe("EncryptInputsBuilder", () => {
       expect(stepCallback).toHaveBeenNthCalledWith(6, EncryptStep.Done);
 
       // Verify ZK methods were called
-      expect(mockZk.getMockPack()).toHaveBeenCalledWith([
+      expect(mockZkPack).toHaveBeenCalledWith([
         {
           data: 100n,
           utype: FheTypes.Uint128,
           securityZone: 0,
         },
       ]);
-      expect(mockZk.getMockProve()).toHaveBeenCalledWith(
-        expect.any(Object),
+      expect(mockZkProve).toHaveBeenCalledWith(
+        expect.any(MockZkListBuilder),
         defaultParams.sender,
         0,
         defaultParams.chainId,
       );
-      expect(mockZk.getMockVerify()).toHaveBeenCalledWith(
+      expect(mockZkVerify).toHaveBeenCalledWith(
         defaultParams.zkVerifierUrl,
-        expect.any(Object),
+        expect.any(MockZkProvenList),
         defaultParams.sender,
         0,
         defaultParams.chainId,
@@ -197,48 +251,72 @@ describe("EncryptInputsBuilder", () => {
       // Verify result structure
       expect(result).toBeDefined();
       expect(Array.isArray(result)).toBe(true);
+
+      // Verify result embedded metadata
+      const [encrypted] = result;
+      const encryptedMetadata = unpackMetadata(encrypted.signature);
+      expect(encryptedMetadata).toBeDefined();
+      expect(encryptedMetadata.signer).toBe(defaultParams.sender);
+      expect(encryptedMetadata.securityZone).toBe(0);
+      expect(encryptedMetadata.chainId).toBe(defaultParams.chainId);
     });
 
     it("should use overridden sender when set", async () => {
       const overriddenSender = "0x5555555555555555555555555555555555555555";
       builder.setSender(overriddenSender);
 
-      await builder.encrypt();
+      const result = await builder.encrypt();
 
-      expect(mockZk.getMockProve()).toHaveBeenCalledWith(
-        expect.any(Object),
+      expect(mockZkProve).toHaveBeenCalledWith(
+        expect.any(MockZkListBuilder),
         overriddenSender,
         0,
         defaultParams.chainId,
       );
-      expect(mockZk.getMockVerify()).toHaveBeenCalledWith(
+      expect(mockZkVerify).toHaveBeenCalledWith(
         defaultParams.zkVerifierUrl,
-        expect.any(Object),
+        expect.any(MockZkProvenList),
         overriddenSender,
         0,
         defaultParams.chainId,
       );
+
+      // Verify result embedded metadata
+      const [encrypted] = result;
+      const encryptedMetadata = unpackMetadata(encrypted.signature);
+      expect(encryptedMetadata).toBeDefined();
+      expect(encryptedMetadata.signer).toBe(overriddenSender);
+      expect(encryptedMetadata.securityZone).toBe(0);
+      expect(encryptedMetadata.chainId).toBe(defaultParams.chainId);
     });
 
     it("should use overridden security zone when set", async () => {
       const overriddenZone = 7;
       builder.setSecurityZone(overriddenZone);
 
-      await builder.encrypt();
+      const result = await builder.encrypt();
 
-      expect(mockZk.getMockProve()).toHaveBeenCalledWith(
-        expect.any(Object),
+      expect(mockZkProve).toHaveBeenCalledWith(
+        expect.any(MockZkListBuilder),
         defaultParams.sender,
         overriddenZone,
         defaultParams.chainId,
       );
-      expect(mockZk.getMockVerify()).toHaveBeenCalledWith(
+      expect(mockZkVerify).toHaveBeenCalledWith(
         defaultParams.zkVerifierUrl,
-        expect.any(Object),
+        expect.any(MockZkProvenList),
         defaultParams.sender,
         overriddenZone,
         defaultParams.chainId,
       );
+
+      // Verify result embedded metadata
+      const [encrypted] = result;
+      const encryptedMetadata = unpackMetadata(encrypted.signature);
+      expect(encryptedMetadata).toBeDefined();
+      expect(encryptedMetadata.signer).toBe(defaultParams.sender);
+      expect(encryptedMetadata.securityZone).toBe(overriddenZone);
+      expect(encryptedMetadata.chainId).toBe(defaultParams.chainId);
     });
 
     it("should work without step callback", async () => {
@@ -259,14 +337,14 @@ describe("EncryptInputsBuilder", () => {
         sender: defaultParams.sender,
         chainId: defaultParams.chainId,
         zkVerifierUrl: defaultParams.zkVerifierUrl,
-        zk: mockZk,
+        zk: defaultParams.zk,
       });
 
       const result = await multiInputBuilder.encrypt();
 
       expect(result).toBeDefined();
       expect(Array.isArray(result)).toBe(true);
-      expect(mockZk.getMockPack()).toHaveBeenCalledWith([
+      expect(mockZkPack).toHaveBeenCalledWith([
         { data: 100n, utype: FheTypes.Uint128, securityZone: 0 },
         { data: true, utype: FheTypes.Bool, securityZone: 0 },
       ]);
@@ -275,7 +353,7 @@ describe("EncryptInputsBuilder", () => {
 
   describe("error handling", () => {
     it("should handle ZK pack errors gracefully", async () => {
-      mockZk.getMockPack().mockImplementation(() => {
+      mockZkPack.mockImplementation(() => {
         throw new Error("ZK pack failed");
       });
 
@@ -283,13 +361,13 @@ describe("EncryptInputsBuilder", () => {
     });
 
     it("should handle ZK prove errors gracefully", async () => {
-      mockZk.getMockProve().mockRejectedValue(new Error("ZK prove failed"));
+      mockZkProve.mockRejectedValue(new Error("ZK prove failed"));
 
       await expect(builder.encrypt()).rejects.toThrow("ZK prove failed");
     });
 
     it("should handle ZK verify errors gracefully", async () => {
-      mockZk.getMockVerify().mockRejectedValue(new Error("ZK verify failed"));
+      mockZkVerify.mockRejectedValue(new Error("ZK verify failed"));
 
       await expect(builder.encrypt()).rejects.toThrow("ZK verify failed");
     });
@@ -297,26 +375,40 @@ describe("EncryptInputsBuilder", () => {
 
   describe("integration scenarios", () => {
     it("should work with the complete builder chain", async () => {
+      const sender = "0x9999999999999999999999999999999999999999";
+      const securityZone = 3;
+
       const stepCallback = vi.fn();
       const result = await builder
-        .setSender("0x9999999999999999999999999999999999999999")
-        .setSecurityZone(3)
+        .setSender(sender)
+        .setSecurityZone(securityZone)
         .setStepCallback(stepCallback)
         .encrypt();
 
       expect(result).toBeDefined();
-      expect(stepCallback).toHaveBeenCalledTimes(5);
-      expect(mockZk.getMockProve()).toHaveBeenCalledWith(
-        expect.any(Object),
-        "0x9999999999999999999999999999999999999999",
-        3,
+      expect(stepCallback).toHaveBeenCalledTimes(6);
+      expect(mockZkProve).toHaveBeenCalledWith(
+        expect.any(MockZkListBuilder),
+        sender,
+        securityZone,
         defaultParams.chainId,
       );
+
+      // Verify result embedded metadata
+      const [encrypted] = result;
+      const encryptedMetadata = unpackMetadata(encrypted.signature);
+      expect(encryptedMetadata).toBeDefined();
+      expect(encryptedMetadata.signer).toBe(sender);
+      expect(encryptedMetadata.securityZone).toBe(securityZone);
+      expect(encryptedMetadata.chainId).toBe(defaultParams.chainId);
     });
 
     it("should maintain state across method calls", async () => {
-      builder.setSender("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-      builder.setSecurityZone(99);
+      const sender = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      const securityZone = 99;
+
+      builder.setSender(sender);
+      builder.setSecurityZone(securityZone);
 
       // Call encrypt multiple times to ensure state is maintained
       const result1 = await builder.encrypt();
@@ -326,12 +418,28 @@ describe("EncryptInputsBuilder", () => {
       expect(result2).toBeDefined();
 
       // Both calls should use the same overridden values
-      expect(mockZk.getMockProve()).toHaveBeenCalledWith(
-        expect.any(Object),
-        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        99,
+      expect(mockZkProve).toHaveBeenCalledWith(
+        expect.any(MockZkListBuilder),
+        sender,
+        securityZone,
         defaultParams.chainId,
       );
+
+      // Verify result embedded metadata
+      const [encrypted1] = result1;
+      const encryptedMetadata1 = unpackMetadata(encrypted1.signature);
+      expect(encryptedMetadata1).toBeDefined();
+      expect(encryptedMetadata1.signer).toBe(sender);
+      expect(encryptedMetadata1.securityZone).toBe(securityZone);
+      expect(encryptedMetadata1.chainId).toBe(defaultParams.chainId);
+
+      // Verify result embedded metadata
+      const [encrypted2] = result2;
+      const encryptedMetadata2 = unpackMetadata(encrypted2.signature);
+      expect(encryptedMetadata2).toBeDefined();
+      expect(encryptedMetadata2.signer).toBe(sender);
+      expect(encryptedMetadata2.securityZone).toBe(securityZone);
+      expect(encryptedMetadata2.chainId).toBe(defaultParams.chainId);
     });
   });
 });

--- a/src/core/encrypt/encryptInput.test.ts
+++ b/src/core/encrypt/encryptInput.test.ts
@@ -1,0 +1,337 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EncryptInputsBuilder } from "./encryptInput";
+import {
+  EncryptStep,
+  Encryptable,
+  EncryptableItem,
+  EncryptableUint128,
+  FheTypes,
+  VerifyResult,
+} from "../../types";
+import { ZkPackProveVerify } from "./zkPackProveVerify";
+import { constructZkPoKMetadata } from "../utils/zkPoK";
+
+class MockZkListBuilder {
+  private items: EncryptableItem[];
+  constructor(items: EncryptableItem[]) {
+    this.items = items;
+  }
+
+  prove(metadata: Uint8Array): MockZkProvenList {
+    return new MockZkProvenList(this.items, metadata);
+  }
+}
+
+const mockZkPack = (items: EncryptableItem[]): MockZkListBuilder => {
+  return new MockZkListBuilder(items);
+};
+
+class MockZkProvenList {
+  private items: EncryptableItem[];
+  private metadata: Uint8Array;
+
+  constructor(items: EncryptableItem[], metadata: Uint8Array) {
+    this.items = items;
+    this.metadata = metadata;
+  }
+
+  verify(): Promise<VerifyResult[]> {
+    return Promise.resolve([
+      { ct_hash: "123456789", signature: "0xabcdef123456789" },
+    ]);
+  }
+}
+
+const mockZkProve = (
+  builder: MockZkListBuilder,
+  address: string,
+  securityZone: number,
+  chainId: string,
+): Promise<MockZkProvenList> => {
+  const metadata = constructZkPoKMetadata(
+    address,
+    securityZone,
+    parseInt(chainId),
+  );
+
+  return Promise.resolve(builder.prove(metadata));
+};
+
+const mockZkVerify = (
+  _verifierUrl: string,
+  proved: MockZkProvenList,
+  _address: string,
+  _securityZone: number,
+  _chainId: string,
+): Promise<VerifyResult[]> => {
+  return Promise.resolve(proved.verify());
+};
+
+describe("EncryptInputsBuilder", () => {
+  const defaultParams = {
+    inputs: [Encryptable.uint128(100n)] as [EncryptableUint128],
+    sender: "0x1234567890123456789012345678901234567890",
+    chainId: "1",
+    zkVerifierUrl: "http://localhost:3001",
+    zk: new ZkPackProveVerify(mockZkPack, mockZkProve, mockZkVerify),
+  };
+  let builder: EncryptInputsBuilder<[EncryptableUint128]>;
+
+  beforeEach(() => {
+    const mockZkPackProveVerify = new ZkPackProveVerify(
+      mockZkPack,
+      mockZkProve,
+      mockZkVerify,
+    );
+    defaultParams.zk = mockZkPackProveVerify;
+    builder = new EncryptInputsBuilder(defaultParams);
+  });
+
+  describe("constructor and initialization", () => {
+    it("should initialize with default values", () => {
+      expect(builder).toBeInstanceOf(EncryptInputsBuilder);
+    });
+
+    it("should set default security zone to 0", () => {
+      const builderWithDefaultZone = new EncryptInputsBuilder({
+        inputs: defaultParams.inputs,
+        sender: defaultParams.sender,
+        chainId: defaultParams.chainId,
+        zkVerifierUrl: defaultParams.zkVerifierUrl,
+        zk: defaultParams.zk,
+        securityZone: undefined,
+      });
+      // We can't directly test private properties, but we can test behavior
+      expect(builderWithDefaultZone).toBeInstanceOf(EncryptInputsBuilder);
+    });
+  });
+
+  describe("setSender", () => {
+    it("should set sender and return builder for chaining", () => {
+      const result = builder.setSender(
+        "0x9876543210987654321098765432109876543210",
+      );
+      expect(result).toBe(builder);
+    });
+
+    it("should allow chaining with other methods", () => {
+      const result = builder
+        .setSender("0x1111111111111111111111111111111111111111")
+        .setSecurityZone(5)
+        .setStepCallback(() => {});
+
+      expect(result).toBe(builder);
+    });
+  });
+
+  describe("setSecurityZone", () => {
+    it("should set security zone and return builder for chaining", () => {
+      const result = builder.setSecurityZone(42);
+      expect(result).toBe(builder);
+    });
+
+    it("should allow chaining with other methods", () => {
+      const result = builder
+        .setSecurityZone(10)
+        .setSender("0x2222222222222222222222222222222222222222");
+
+      expect(result).toBe(builder);
+    });
+  });
+
+  describe("setStepCallback", () => {
+    it("should set step callback and return builder for chaining", () => {
+      const callback = vi.fn();
+      const result = builder.setStepCallback(callback);
+      expect(result).toBe(builder);
+    });
+
+    it("should allow chaining with other methods", () => {
+      const callback = vi.fn();
+      const result = builder.setStepCallback(callback).setSecurityZone(15);
+
+      expect(result).toBe(builder);
+    });
+  });
+
+  describe("encrypt", () => {
+    it("should execute the full encryption flow with step callbacks", async () => {
+      const stepCallback = vi.fn();
+      builder.setStepCallback(stepCallback);
+
+      const result = await builder.encrypt();
+
+      // Verify step callbacks were called in order
+      expect(stepCallback).toHaveBeenCalledTimes(5);
+      expect(stepCallback).toHaveBeenNthCalledWith(1, EncryptStep.Extract);
+      expect(stepCallback).toHaveBeenNthCalledWith(2, EncryptStep.Pack);
+      expect(stepCallback).toHaveBeenNthCalledWith(3, EncryptStep.Prove);
+      expect(stepCallback).toHaveBeenNthCalledWith(4, EncryptStep.Verify);
+      expect(stepCallback).toHaveBeenNthCalledWith(5, EncryptStep.Replace);
+      expect(stepCallback).toHaveBeenNthCalledWith(6, EncryptStep.Done);
+
+      // Verify ZK methods were called
+      expect(mockZk.getMockPack()).toHaveBeenCalledWith([
+        {
+          data: 100n,
+          utype: FheTypes.Uint128,
+          securityZone: 0,
+        },
+      ]);
+      expect(mockZk.getMockProve()).toHaveBeenCalledWith(
+        expect.any(Object),
+        defaultParams.sender,
+        0,
+        defaultParams.chainId,
+      );
+      expect(mockZk.getMockVerify()).toHaveBeenCalledWith(
+        defaultParams.zkVerifierUrl,
+        expect.any(Object),
+        defaultParams.sender,
+        0,
+        defaultParams.chainId,
+      );
+
+      // Verify result structure
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it("should use overridden sender when set", async () => {
+      const overriddenSender = "0x5555555555555555555555555555555555555555";
+      builder.setSender(overriddenSender);
+
+      await builder.encrypt();
+
+      expect(mockZk.getMockProve()).toHaveBeenCalledWith(
+        expect.any(Object),
+        overriddenSender,
+        0,
+        defaultParams.chainId,
+      );
+      expect(mockZk.getMockVerify()).toHaveBeenCalledWith(
+        defaultParams.zkVerifierUrl,
+        expect.any(Object),
+        overriddenSender,
+        0,
+        defaultParams.chainId,
+      );
+    });
+
+    it("should use overridden security zone when set", async () => {
+      const overriddenZone = 7;
+      builder.setSecurityZone(overriddenZone);
+
+      await builder.encrypt();
+
+      expect(mockZk.getMockProve()).toHaveBeenCalledWith(
+        expect.any(Object),
+        defaultParams.sender,
+        overriddenZone,
+        defaultParams.chainId,
+      );
+      expect(mockZk.getMockVerify()).toHaveBeenCalledWith(
+        defaultParams.zkVerifierUrl,
+        expect.any(Object),
+        defaultParams.sender,
+        overriddenZone,
+        defaultParams.chainId,
+      );
+    });
+
+    it("should work without step callback", async () => {
+      // No step callback set
+      const result = await builder.encrypt();
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+      // Should not throw when no callback is set
+    });
+
+    it("should handle multiple input types", async () => {
+      const multiInputBuilder = new EncryptInputsBuilder({
+        inputs: [Encryptable.uint128(100n), Encryptable.bool(true)] as [
+          ReturnType<typeof Encryptable.uint128>,
+          ReturnType<typeof Encryptable.bool>,
+        ],
+        sender: defaultParams.sender,
+        chainId: defaultParams.chainId,
+        zkVerifierUrl: defaultParams.zkVerifierUrl,
+        zk: mockZk,
+      });
+
+      const result = await multiInputBuilder.encrypt();
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+      expect(mockZk.getMockPack()).toHaveBeenCalledWith([
+        { data: 100n, utype: FheTypes.Uint128, securityZone: 0 },
+        { data: true, utype: FheTypes.Bool, securityZone: 0 },
+      ]);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle ZK pack errors gracefully", async () => {
+      mockZk.getMockPack().mockImplementation(() => {
+        throw new Error("ZK pack failed");
+      });
+
+      await expect(builder.encrypt()).rejects.toThrow("ZK pack failed");
+    });
+
+    it("should handle ZK prove errors gracefully", async () => {
+      mockZk.getMockProve().mockRejectedValue(new Error("ZK prove failed"));
+
+      await expect(builder.encrypt()).rejects.toThrow("ZK prove failed");
+    });
+
+    it("should handle ZK verify errors gracefully", async () => {
+      mockZk.getMockVerify().mockRejectedValue(new Error("ZK verify failed"));
+
+      await expect(builder.encrypt()).rejects.toThrow("ZK verify failed");
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should work with the complete builder chain", async () => {
+      const stepCallback = vi.fn();
+      const result = await builder
+        .setSender("0x9999999999999999999999999999999999999999")
+        .setSecurityZone(3)
+        .setStepCallback(stepCallback)
+        .encrypt();
+
+      expect(result).toBeDefined();
+      expect(stepCallback).toHaveBeenCalledTimes(5);
+      expect(mockZk.getMockProve()).toHaveBeenCalledWith(
+        expect.any(Object),
+        "0x9999999999999999999999999999999999999999",
+        3,
+        defaultParams.chainId,
+      );
+    });
+
+    it("should maintain state across method calls", async () => {
+      builder.setSender("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+      builder.setSecurityZone(99);
+
+      // Call encrypt multiple times to ensure state is maintained
+      const result1 = await builder.encrypt();
+      const result2 = await builder.encrypt();
+
+      expect(result1).toBeDefined();
+      expect(result2).toBeDefined();
+
+      // Both calls should use the same overridden values
+      expect(mockZk.getMockProve()).toHaveBeenCalledWith(
+        expect.any(Object),
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        99,
+        defaultParams.chainId,
+      );
+    });
+  });
+});

--- a/src/core/encrypt/encryptInput.ts
+++ b/src/core/encrypt/encryptInput.ts
@@ -55,9 +55,17 @@ export class EncryptInputsBuilder<T extends any[]> {
     return this;
   }
 
+  getSender(): string {
+    return this.sender;
+  }
+
   setSecurityZone(securityZone: number): EncryptInputsBuilder<T> {
     this.securityZone = securityZone;
     return this;
+  }
+
+  getSecurityZone(): number {
+    return this.securityZone;
   }
 
   /**

--- a/src/core/encrypt/encryptInput.ts
+++ b/src/core/encrypt/encryptInput.ts
@@ -1,0 +1,197 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  EncryptStep,
+  EncryptSetStateFn,
+  CoFheInItem,
+  Encrypted_Inputs,
+} from "../../types";
+import { encryptExtract, encryptReplace } from "../sdk/index";
+import { CofhejsError, CofhejsErrorCode } from "../../types";
+import { ZkPackProveVerify } from "./zkPackProveVerify";
+
+export class EncryptInputsBuilder<T extends any[]> {
+  private sender?: string;
+  private chainId?: string;
+  private securityZone?: number;
+  private stepCallback?: EncryptSetStateFn;
+  private inputItems?: [...T];
+  private zkVerifierUrl?: string;
+  private zk?: ZkPackProveVerify<any, any>;
+
+  constructor(params: {
+    inputs: [...T];
+    sender?: string;
+    chainId?: string;
+    zkVerifierUrl: string;
+    zk: ZkPackProveVerify<any, any>;
+  }) {
+    this.inputItems = params.inputs;
+    this.sender = params.sender;
+    this.chainId = params.chainId;
+    this.zkVerifierUrl = params.zkVerifierUrl;
+    this.zk = params.zk;
+  }
+
+  /**
+   * @param sender - The overridden msg.sender of the transaction that will consume the encrypted inputs.
+   *
+   * If not provided, the account initialized in `cofhejs.initialize` will be used.
+   * Used when msg.sender is known to be different from the account initialized in `cofhejs.initialize`,
+   * for example when using a paymaster.
+   *
+   * Example:
+   * ```typescript
+   * const encrypted = await encryptInputs([Encryptable.uint128(10n)])
+   *   .setSender("0x123")
+   *   .encrypt();
+   * ```
+   *
+   * @returns The EncryptInputsBuilder instance.
+   */
+  setSender(sender: string): EncryptInputsBuilder<T> {
+    this.sender = sender;
+    return this;
+  }
+
+  setSecurityZone(securityZone: number): EncryptInputsBuilder<T> {
+    this.securityZone = securityZone;
+    return this;
+  }
+
+  /**
+   * @param callback - A function that will be called with the current step of the encryption process.
+   *
+   * Useful for debugging and tracking the progress of the encryption process.
+   * Useful for a UI element that shows the progress of the encryption process.
+   *
+   * Example:
+   * ```typescript
+   * const encrypted = await encryptInputs([Encryptable.uint128(10n)])
+   *   .setStepCallback((step: EncryptStep) => console.log(step))
+   *   .encrypt();
+   * ```
+   *
+   * @returns The EncryptInputsBuilder instance.
+   */
+  setStepCallback(callback: EncryptSetStateFn): EncryptInputsBuilder<T> {
+    this.stepCallback = callback;
+    return this;
+  }
+
+  private fireCallback(step: EncryptStep) {
+    if (!this.stepCallback) return;
+    this.stepCallback(step);
+  }
+
+  private getResolvedSecurityZone() {
+    return this.securityZone ?? 0;
+  }
+
+  private getResolvedSender() {
+    if (this.sender) return this.sender;
+
+    throw new CofhejsError({
+      code: CofhejsErrorCode.AccountUninitialized,
+      message: "No sender provided and no account initialized",
+    });
+  }
+
+  private getResolvedChainId() {
+    if (this.chainId) return this.chainId;
+
+    throw new CofhejsError({
+      code: CofhejsErrorCode.ChainIdUninitialized,
+      message: "No chainId provided and no chainId initialized",
+    });
+  }
+
+  private getResolvedInputItems() {
+    if (this.inputItems) return this.inputItems;
+
+    throw new CofhejsError({
+      code: CofhejsErrorCode.InvalidPermitData,
+      message:
+        "No inputs provided. Call .inputs() with at least one EncryptableItem.",
+    });
+  }
+
+  private getResolvedZk() {
+    if (this.zk) return this.zk;
+    throw new CofhejsError({
+      code: CofhejsErrorCode.ZkUninitialized,
+      message: "No zk provided and no zk initialized",
+    });
+  }
+
+  private getResolvedZkVerifierUrl() {
+    if (this.zkVerifierUrl) return this.zkVerifierUrl;
+    throw new CofhejsError({
+      code: CofhejsErrorCode.ZkVerifierUrlUninitialized,
+      message: "No zkVerifierUrl provided and no zkVerifierUrl initialized",
+    });
+  }
+
+  private getExtractedEncryptableItems() {
+    const inputItems = this.getResolvedInputItems();
+    return encryptExtract(inputItems);
+  }
+
+  private replaceEncryptableItems(inItems: CoFheInItem[]) {
+    const inputItems = this.getResolvedInputItems();
+    const [prepared, remaining] = encryptReplace(inputItems, inItems);
+    if (remaining.length === 0) return prepared;
+
+    throw new CofhejsError({
+      code: CofhejsErrorCode.EncryptRemainingInItems,
+      message: "Some encrypted inputs remaining after replacement",
+    });
+  }
+
+  async encrypt(): Promise<[...Encrypted_Inputs<T>]> {
+    const sender = this.getResolvedSender();
+    const chainId = this.getResolvedChainId();
+    const securityZone = this.getResolvedSecurityZone();
+    const zkVerifierUrl = this.getResolvedZkVerifierUrl();
+    const zk = this.getResolvedZk();
+
+    this.fireCallback(EncryptStep.Extract);
+
+    const encryptableItems = this.getExtractedEncryptableItems();
+
+    this.fireCallback(EncryptStep.Pack);
+
+    const builder = zk.pack(encryptableItems);
+
+    this.fireCallback(EncryptStep.Prove);
+
+    const proved = await zk.prove(builder, sender, securityZone, chainId);
+
+    this.fireCallback(EncryptStep.Verify);
+
+    const verifyResults = await zk.verify(
+      zkVerifierUrl,
+      proved,
+      sender,
+      securityZone,
+      chainId,
+    );
+
+    // Add securityZone and utype to the verify results
+    const inItems: CoFheInItem[] = verifyResults.map(
+      ({ ct_hash, signature }, index) => ({
+        ctHash: BigInt(ct_hash),
+        securityZone: securityZone,
+        utype: encryptableItems[index].utype,
+        signature,
+      }),
+    );
+
+    this.fireCallback(EncryptStep.Replace);
+
+    const preparedInputItems = this.replaceEncryptableItems(inItems);
+
+    this.fireCallback(EncryptStep.Done);
+
+    return preparedInputItems;
+  }
+}

--- a/src/core/encrypt/encryptInput.ts
+++ b/src/core/encrypt/encryptInput.ts
@@ -99,6 +99,17 @@ export class EncryptInputsBuilder<T extends any[]> {
     });
   }
 
+  /**
+   * Final step of the encryption process. MUST BE CALLED LAST IN THE CHAIN.
+   *
+   * This will:
+   * - Extract the encryptable items from the inputs
+   * - Pack the encryptable items into a zk proof
+   * - Prove the zk proof
+   * - Verify the zk proof
+   *
+   * @returns The encrypted inputs.
+   */
   async encrypt(): Promise<[...Encrypted_Inputs<T>]> {
     this.fireCallback(EncryptStep.Extract);
 

--- a/src/core/encrypt/zkPackProveVerify.ts
+++ b/src/core/encrypt/zkPackProveVerify.ts
@@ -1,0 +1,61 @@
+import { EncryptableItem, VerifyResult } from "../../types";
+
+type ZkPackFunction<B> = (items: EncryptableItem[]) => B;
+type ZkProveFunction<B, P> = (
+  builder: B,
+  address: string,
+  securityZone: number,
+  chainId: string,
+) => Promise<P>;
+type ZkVerifyFunction<P> = (
+  verifierUrl: string,
+  compactList: P,
+  address: string,
+  securityZone: number,
+  chainId: string,
+) => Promise<VerifyResult[]>;
+
+export class ZkPackProveVerify<B, P> {
+  private zkPack: ZkPackFunction<B>;
+  private zkProve: ZkProveFunction<B, P>;
+  private zkVerify: ZkVerifyFunction<P>;
+
+  constructor(
+    zkPack: ZkPackFunction<B>,
+    zkProve: ZkProveFunction<B, P>,
+    zkVerify: ZkVerifyFunction<P>,
+  ) {
+    this.zkPack = zkPack;
+    this.zkProve = zkProve;
+    this.zkVerify = zkVerify;
+  }
+
+  pack(items: EncryptableItem[]): B {
+    return this.zkPack(items);
+  }
+
+  prove(
+    builder: B,
+    address: string,
+    securityZone: number,
+    chainId: string,
+  ): Promise<P> {
+    return this.zkProve(builder, address, securityZone, chainId);
+  }
+
+  verify(
+    verifierUrl: string,
+    compactList: P,
+    address: string,
+    securityZone: number,
+    chainId: string,
+  ): Promise<VerifyResult[]> {
+    return this.zkVerify(
+      verifierUrl,
+      compactList,
+      address,
+      securityZone,
+      chainId,
+    );
+  }
+}

--- a/src/core/sdk/index.ts
+++ b/src/core/sdk/index.ts
@@ -21,9 +21,6 @@ import {
   CofhejsError,
   CofhejsErrorCode,
   wrapFunction,
-  Result,
-  ResultErr,
-  ResultOk,
 } from "../../types";
 import { mockDecrypt, mockSealOutput } from "./testnet";
 import { bytesToBigInt } from "../utils";
@@ -160,7 +157,11 @@ export const createPermit = async (
   const permit = await Permit.createAndSign(optionsWithDefaults, state.signer);
 
   permitStore.setPermit(state.chainId!, state.account!, permit);
-  permitStore.setActivePermitHash(state.chainId!, state.account!, permit.getHash());
+  permitStore.setActivePermitHash(
+    state.chainId!,
+    state.account!,
+    permit.getHash(),
+  );
 
   return permit;
 };
@@ -224,7 +225,11 @@ export const importPermit = async (
   }
 
   permitStore.setPermit(state.chainId!, state.account!, permit);
-  permitStore.setActivePermitHash(state.chainId!, state.account!, permit.getHash());
+  permitStore.setActivePermitHash(
+    state.chainId!,
+    state.account!,
+    permit.getHash(),
+  );
 
   return permit;
 };
@@ -248,7 +253,11 @@ export const selectActivePermit = (hash: string): Permit => {
       message: `Permit with hash <${hash}> not found`,
     });
 
-  permitStore.setActivePermitHash(state.chainId!, state.account!, permit.getHash());
+  permitStore.setActivePermitHash(
+    state.chainId!,
+    state.account!,
+    permit.getHash(),
+  );
 
   return permit;
 };
@@ -292,7 +301,7 @@ export const getPermit_asResult = wrapFunction(getPermit);
  * Removes a permit from the store based on its hash.
  * If removing the active permit and other permits exist, automatically sets a new active permit.
  * If removing the last permit, requires the `force` flag to be true, otherwise throws an error.
- * 
+ *
  * @param {string} hash - The `Permit.getHash` of the permit to remove.
  * @param {boolean} force - Optional flag to force removal of the last permit. Defaults to false.
  * @returns {string} - The hash of the removed permit.
@@ -307,7 +316,7 @@ export const removePermit = (hash: string, force?: boolean): string => {
     });
   }
 
-  try { 
+  try {
     permitStore.removePermit(state.chainId!, state.account!, hash, force);
   } catch (e) {
     throw new CofhejsError({

--- a/src/core/sdk/testnet.ts
+++ b/src/core/sdk/testnet.ts
@@ -172,9 +172,9 @@ async function mockZkVerifySign(
 export async function mockEncrypt<T extends any[]>(
   item: [...T],
   securityZone = 0,
-  setStateCallback: EncryptSetStateFn,
+  setStateCallback?: EncryptSetStateFn,
 ): Promise<[...Encrypted_Inputs<T>]> {
-  setStateCallback(EncryptStep.Extract);
+  setStateCallback?.(EncryptStep.Extract);
 
   const state = _sdkStore.getState();
 
@@ -204,16 +204,16 @@ export async function mockEncrypt<T extends any[]>(
 
   const encryptableItems = encryptExtract(item);
 
-  setStateCallback(EncryptStep.Pack);
+  setStateCallback?.(EncryptStep.Pack);
 
   // Sleep to avoid rate limiting
   await sleep(100);
 
-  setStateCallback(EncryptStep.Prove);
+  setStateCallback?.(EncryptStep.Prove);
 
   await sleep(500);
 
-  setStateCallback(EncryptStep.Verify);
+  setStateCallback?.(EncryptStep.Verify);
 
   await sleep(500);
 
@@ -235,7 +235,7 @@ export async function mockEncrypt<T extends any[]>(
     }),
   );
 
-  setStateCallback(EncryptStep.Replace);
+  setStateCallback?.(EncryptStep.Replace);
 
   const [preparedInputItems, remainingInItems] = encryptReplace(item, inItems);
 
@@ -245,7 +245,7 @@ export async function mockEncrypt<T extends any[]>(
       message: "Some encrypted inputs remaining after replacement",
     });
 
-  setStateCallback(EncryptStep.Done);
+  setStateCallback?.(EncryptStep.Done);
 
   return preparedInputItems;
 }

--- a/src/node/sdk.ts
+++ b/src/node/sdk.ts
@@ -130,6 +130,9 @@ async function initializeWithEthers(
 // NOTE: This function returns the result type directly
 // Usually we use wrapFunctionAsync to wrap this function
 // but in this case the input types are too complex
+/**
+ * @deprecated This function is deprecated. Use {@link encryptInputs} instead for better type safety and improved functionality.
+ */
 async function encrypt<T extends any[]>(
   item: [...T],
   setStateCallback?: (state: EncryptStep) => void,

--- a/src/node/sdk.ts
+++ b/src/node/sdk.ts
@@ -252,6 +252,8 @@ async function encrypt<T extends any[]>(
 export function encryptInputs<T extends any[]>(
   inputs: [...T],
 ): EncryptInputsBuilder<[...T]> {
+  const state = _sdkStore.getState();
+
   const { fhePublicKey, crs, verifierUrl, account, chainId } = encryptGetKeys();
 
   const _zkPack = (items: EncryptableItem[]) => {
@@ -279,6 +281,7 @@ export function encryptInputs<T extends any[]>(
     inputs,
     sender: account,
     chainId,
+    isTestnet: state.isTestnet,
     zkVerifierUrl: verifierUrl,
     zk: zkPackProveVerify,
   });

--- a/src/node/sdk.ts
+++ b/src/node/sdk.ts
@@ -120,6 +120,11 @@ async function initializeWithEthers(
   });
 }
 
+let overriddenAccount: string | undefined;
+const encryptOverrideAccount = (account: string) => {
+  overriddenAccount = account;
+};
+
 // NOTE: This function returns the result type directly
 // Usually we use wrapFunctionAsync to wrap this function
 // but in this case the input types are too complex
@@ -159,6 +164,9 @@ async function encrypt<T extends any[]>(
 
     const { fhePublicKey, crs, verifierUrl, account, chainId } = keysResult;
 
+    const accountOrOverride = overriddenAccount ?? account;
+    console.log("accountOrOverride", accountOrOverride);
+
     const encryptableItems = encryptExtract(item);
 
     setStateCallback(EncryptStep.Pack);
@@ -173,7 +181,7 @@ async function encrypt<T extends any[]>(
     const proved = await zkProve(
       builder,
       CompactPkeCrs.deserialize(crs),
-      account,
+      accountOrOverride,
       securityZone,
       chainId,
     );
@@ -183,7 +191,7 @@ async function encrypt<T extends any[]>(
     const verifyResults = await zkVerify(
       verifierUrl,
       proved,
-      account,
+      accountOrOverride,
       securityZone,
       chainId,
     );
@@ -239,4 +247,6 @@ export const cofhejs = {
   unseal: wrapFunctionAsync(unseal),
   decrypt: wrapFunctionAsync(decrypt),
 
+  // TEMP
+  encryptOverrideAccount,
 };

--- a/src/node/sdk.ts
+++ b/src/node/sdk.ts
@@ -127,11 +127,6 @@ async function initializeWithEthers(
   });
 }
 
-let overriddenAccount: string | undefined;
-const encryptOverrideAccount = (account: string) => {
-  overriddenAccount = account;
-};
-
 // NOTE: This function returns the result type directly
 // Usually we use wrapFunctionAsync to wrap this function
 // but in this case the input types are too complex
@@ -171,9 +166,6 @@ async function encrypt<T extends any[]>(
 
     const { fhePublicKey, crs, verifierUrl, account, chainId } = keysResult;
 
-    const accountOrOverride = overriddenAccount ?? account;
-    console.log("accountOrOverride", accountOrOverride);
-
     const encryptableItems = encryptExtract(item);
 
     setStateCallback(EncryptStep.Pack);
@@ -188,7 +180,7 @@ async function encrypt<T extends any[]>(
     const proved = await zkProve(
       builder,
       CompactPkeCrs.deserialize(crs),
-      accountOrOverride,
+      account,
       securityZone,
       chainId,
     );
@@ -198,7 +190,7 @@ async function encrypt<T extends any[]>(
     const verifyResults = await zkVerify(
       verifierUrl,
       proved,
-      accountOrOverride,
+      account,
       securityZone,
       chainId,
     );
@@ -308,7 +300,4 @@ export const cofhejs = {
 
   unseal: wrapFunctionAsync(unseal),
   decrypt: wrapFunctionAsync(decrypt),
-
-  // TEMP
-  encryptOverrideAccount,
 };

--- a/src/node/sdk.ts
+++ b/src/node/sdk.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { CompactPkeCrs, TfheCompactPublicKey } from "node-tfhe";
+import {
+  CompactCiphertextListBuilder,
+  CompactPkeCrs,
+  TfheCompactPublicKey,
+} from "node-tfhe";
 import {
   createPermit,
   encryptExtract,
@@ -31,6 +35,7 @@ import {
   Permission,
   ResultOk,
   ResultErrOrInternal,
+  EncryptableItem,
 } from "../types";
 import { initTfhe } from "./init";
 import { zkPack, zkProve, zkVerify } from "./zkPoK";
@@ -43,6 +48,8 @@ import {
   ViemInitializerParams,
 } from "../core/sdk/initializers";
 import { marshallEncryptParams } from "../core/utils";
+import { ZkPackProveVerify } from "../core/encrypt/zkPackProveVerify";
+import { EncryptInputsBuilder } from "../core/encrypt/encryptInput";
 
 /**
  * Initializes the `cofhejs` to enable encrypting input data, creating permits / permissions, and decrypting sealed outputs.
@@ -226,6 +233,57 @@ async function encrypt<T extends any[]>(
   }
 }
 
+/**
+ * Creates a new EncryptInputsBuilder instance for chaining encryption operations.
+ * This starts the function chaining pattern for encrypting inputs.
+ *
+ * @returns {EncryptInputsBuilder} A builder instance for configuring and executing encryption
+ *
+ * @example
+ * ```typescript
+ * const encrypted = await cofhejs
+ *   .encryptInputs([Encryptable.uint128(value)])
+ *   .setSender(paymasterData.address)
+ *   .setSecurityZone(0)
+ *   .setStepCallback((step) => console.log(step))
+ *   .encrypt();
+ * ```
+ */
+export function encryptInputs<T extends any[]>(
+  inputs: [...T],
+): EncryptInputsBuilder<[...T]> {
+  const { fhePublicKey, crs, verifierUrl, account, chainId } = encryptGetKeys();
+
+  const _zkPack = (items: EncryptableItem[]) => {
+    return zkPack(items, TfheCompactPublicKey.deserialize(fhePublicKey));
+  };
+
+  const _zkProve = (
+    builder: CompactCiphertextListBuilder,
+    address: string,
+    securityZone: number,
+    chainId: string,
+  ) => {
+    return zkProve(
+      builder,
+      CompactPkeCrs.deserialize(crs),
+      address,
+      securityZone,
+      chainId,
+    );
+  };
+
+  const zkPackProveVerify = new ZkPackProveVerify(_zkPack, _zkProve, zkVerify);
+
+  return new EncryptInputsBuilder<[...T]>({
+    inputs,
+    sender: account,
+    chainId,
+    zkVerifierUrl: verifierUrl,
+    zk: zkPackProveVerify,
+  });
+}
+
 export const cofhejs = {
   store: _sdkStore,
   initialize: wrapFunctionAsync(initialize),
@@ -243,6 +301,7 @@ export const cofhejs = {
   getAllPermits: wrapFunction(getAllPermits),
 
   encrypt: encrypt,
+  encryptInputs: encryptInputs,
 
   unseal: wrapFunctionAsync(unseal),
   decrypt: wrapFunctionAsync(decrypt),

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -27,6 +27,8 @@ export enum CofhejsErrorCode {
   ZkVerifySignFailed = "ZK_VERIFY_SIGN_FAILED",
   ZkVerifyFailed = "ZK_VERIFY_FAILED",
   EncryptRemainingInItems = "ENCRYPT_REMAINING_IN_ITEMS",
+  ZkUninitialized = "ZK_UNINITIALIZED",
+  ZkVerifierUrlUninitialized = "ZK_VERIFIER_URL_UNINITIALIZED",
 }
 
 export class CofhejsError extends Error {

--- a/src/web/sdk.ts
+++ b/src/web/sdk.ts
@@ -130,6 +130,9 @@ async function initializeWithEthers(
 // NOTE: This function returns the result type directly
 // Usually we use wrapFunctionAsync to wrap this function
 // but in this case the input types are too complex
+/**
+ * @deprecated This function is deprecated. Use {@link encryptInputs} instead for better type safety and improved functionality.
+ */
 async function encrypt<T extends any[]>(
   item: [...T],
   setStateCallback?: (state: EncryptStep) => void,

--- a/src/web/sdk.ts
+++ b/src/web/sdk.ts
@@ -120,6 +120,11 @@ async function initializeWithEthers(
   });
 }
 
+let overriddenAccount: string | undefined;
+const encryptOverrideAccount = (account: string) => {
+  overriddenAccount = account;
+};
+
 // NOTE: This function returns the result type directly
 // Usually we use wrapFunctionAsync to wrap this function
 // but in this case the input types are too complex
@@ -159,6 +164,9 @@ async function encrypt<T extends any[]>(
 
     const { fhePublicKey, crs, verifierUrl, account, chainId } = keysResult;
 
+    const accountOrOverride = overriddenAccount ?? account;
+    console.log("accountOrOverride", accountOrOverride);
+
     const encryptableItems = encryptExtract(item);
 
     setStateCallback(EncryptStep.Pack);
@@ -173,7 +181,7 @@ async function encrypt<T extends any[]>(
     const proved = await zkProve(
       builder,
       CompactPkeCrs.deserialize(crs),
-      account,
+      accountOrOverride,
       securityZone,
       chainId,
     );
@@ -183,7 +191,7 @@ async function encrypt<T extends any[]>(
     const verifyResults = await zkVerify(
       verifierUrl,
       proved,
-      account,
+      accountOrOverride,
       securityZone,
       chainId,
     );
@@ -238,4 +246,7 @@ export const cofhejs = {
 
   unseal: wrapFunctionAsync(unseal),
   decrypt: wrapFunctionAsync(decrypt),
+
+  // TEMP
+  encryptOverrideAccount,
 };

--- a/src/web/sdk.ts
+++ b/src/web/sdk.ts
@@ -127,11 +127,6 @@ async function initializeWithEthers(
   });
 }
 
-let overriddenAccount: string | undefined;
-const encryptOverrideAccount = (account: string) => {
-  overriddenAccount = account;
-};
-
 // NOTE: This function returns the result type directly
 // Usually we use wrapFunctionAsync to wrap this function
 // but in this case the input types are too complex
@@ -171,9 +166,6 @@ async function encrypt<T extends any[]>(
 
     const { fhePublicKey, crs, verifierUrl, account, chainId } = keysResult;
 
-    const accountOrOverride = overriddenAccount ?? account;
-    console.log("accountOrOverride", accountOrOverride);
-
     const encryptableItems = encryptExtract(item);
 
     setStateCallback(EncryptStep.Pack);
@@ -188,7 +180,7 @@ async function encrypt<T extends any[]>(
     const proved = await zkProve(
       builder,
       CompactPkeCrs.deserialize(crs),
-      accountOrOverride,
+      account,
       securityZone,
       chainId,
     );
@@ -198,7 +190,7 @@ async function encrypt<T extends any[]>(
     const verifyResults = await zkVerify(
       verifierUrl,
       proved,
-      accountOrOverride,
+      account,
       securityZone,
       chainId,
     );
@@ -308,7 +300,4 @@ export const cofhejs = {
 
   unseal: wrapFunctionAsync(unseal),
   decrypt: wrapFunctionAsync(decrypt),
-
-  // TEMP
-  encryptOverrideAccount,
 };

--- a/test/arb-sepolia.test.ts
+++ b/test/arb-sepolia.test.ts
@@ -143,6 +143,11 @@ describe("Arbitrum Sepolia Tests", () => {
       console.log(`Log Encrypt State :: ${state}`);
     };
 
+    console.log(
+      "TEST TEST TEST\n\n\n\nTEST TEST TEST TEST\n\n\n\nTEST TEST TEST",
+    );
+    cofhejs.encryptOverrideAccount("0xABCDEF");
+
     const nestedEncryptResult = await cofhejs.encrypt(
       [
         { a: Encryptable.bool(false), b: Encryptable.uint64(10n), c: "hello" },

--- a/test/arb-sepolia.test.ts
+++ b/test/arb-sepolia.test.ts
@@ -181,19 +181,16 @@ describe("Arbitrum Sepolia Tests", () => {
       issuer: bobAddress,
     });
 
-    const logState = (state: EncryptStep) => {
-      console.log(`Log Encrypt State :: ${state}`);
-    };
-
-    const nestedEncrypt = await cofhejs
+    const encryptResult = await cofhejs
       .encryptInputs([Encryptable.uint8("10")])
-      .setStepCallback(logState)
       .encrypt();
+
+    const encryptData = expectResultSuccess(encryptResult);
 
     type ExpectedEncryptedType = [CoFheInUint8];
 
     console.log("bob address", bobAddress);
-    console.log(nestedEncrypt);
-    expectTypeOf<ExpectedEncryptedType>().toEqualTypeOf(nestedEncrypt);
+    console.log(encryptData);
+    expectTypeOf<ExpectedEncryptedType>().toEqualTypeOf(encryptData);
   });
 });

--- a/test/arb-sepolia.test.ts
+++ b/test/arb-sepolia.test.ts
@@ -172,4 +172,28 @@ describe("Arbitrum Sepolia Tests", () => {
     console.log(nestedEncrypt);
     expectTypeOf<ExpectedEncryptedType>().toEqualTypeOf(nestedEncrypt);
   });
+
+  it("encryptInputs", { timeout: 320000 }, async () => {
+    await initSdkWithBob();
+
+    await cofhejs.createPermit({
+      type: "self",
+      issuer: bobAddress,
+    });
+
+    const logState = (state: EncryptStep) => {
+      console.log(`Log Encrypt State :: ${state}`);
+    };
+
+    const nestedEncrypt = await cofhejs
+      .encryptInputs([Encryptable.uint8("10")])
+      .setStepCallback(logState)
+      .encrypt();
+
+    type ExpectedEncryptedType = [CoFheInUint8];
+
+    console.log("bob address", bobAddress);
+    console.log(nestedEncrypt);
+    expectTypeOf<ExpectedEncryptedType>().toEqualTypeOf(nestedEncrypt);
+  });
 });


### PR DESCRIPTION
Refactored encrypt function named `encryptInput`

Breaks apart the encrypt inputs and options to improve the api. Also introduces the ability to override the sender embedded in the encrypted inputs.

New api:
```typescript
 const encrypted = await cofhejs
   .encryptInputs([Encryptable.uint128(value)])
   .setSender(paymasterData.address) // optional - defaults to cofhejs initialized sender
   .setSecurityZone(0) // optional - defaults to 0
   .setStepCallback((step) => console.log(step)) // optional - used for debugging and UIs
   .encrypt();
 ```