### PR TITLE
fix: update README from legacy fhenixjs branding to cofhejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,32 +3,32 @@
 </p>
 
 <p align="center">
-  The JavaScript SDK for Fhenix
+  The JavaScript SDK for CoFHE by Fhenix
 </p>
 
 <p align="center">
-  <img alt="npm" src="https://img.shields.io/npm/v/fhenixjs" />
-  <img alt="ci" style="margin-left: 0.3em" src="https://github.com/fhenixprotocol/fhenix.js/actions/workflows/test.yml/badge.svg?branch=main" />
+  <img alt="npm" src="https://img.shields.io/npm/v/cofhejs" />
+  <img alt="ci" style="margin-left: 0.3em" src="https://github.com/FhenixProtocol/cofhejs/actions/workflows/test.yml/badge.svg?branch=main" />
 </p>
 
 <p align="center">
-  <a href="https://fhenixjs.fhenix.zone" target="_blank"><strong>Explore the Docs »</strong></a>
+  <a href="https://cofhe-docs.fhenix.zone" target="_blank"><strong>Explore the Docs »</strong></a>
 </p>
 
 ## General
 
-fhenix.js allows developers to add support for encrypted data when developing dApps on Fhenix.
-fhenix.js includes easy helpers for encryption, unsealing and helpers to create apps that utilize private data.
+cofhejs allows developers to add support for encrypted data when developing dApps with CoFHE.
+cofhejs includes easy helpers for encryption, unsealing, and permits to create apps that utilize private data.
 
 ## Installation
 
 ### NodeJS
 
-(only node 20+ is supported until I fix this)
+Node.js 20+ is required.
 
 ```bash
 # Using npm
-npm install fhenixjs
+npm install cofhejs
 ```
 
 ### Browser Installation (or simpler bundling)
@@ -38,7 +38,7 @@ which is available in the ./dist/ folder in this repo.
 
 You can also install from a CDN e.g.
 
-`https://cdn.jsdelivr.net/npm/fhenixjs@0.3.0-alpha.1/dist/fhenix.umd.min.js`
+`https://cdn.jsdelivr.net/npm/cofhejs/dist/fhenix.umd.min.js`
 
 #### ESM
 
@@ -46,7 +46,7 @@ You can install as a module:
 
 ```
 <script type="module">
-    import { fhenixjs } from "./dist/fhenix.esm.min.js";
+    import { cofhejs } from "cofhejs/web";
 </script>
 ```
 
@@ -60,11 +60,11 @@ Or from a UMD:
 
 #### NextJS WASM Bundling
 
-FhenixJS uses WASM for all the FHE goodness. If you're using the non-prepackaged version you'll need to configure next.js to properly use WASM via the `next.config.js` file. 
+cofhejs uses WASM for all the FHE goodness. If you're using the non-prepackaged version you'll need to configure next.js to properly use WASM via the `next.config.js` file. 
 
 Otherwise, you can use the prepackaged version above that avoids having to bundle WASM.
 
-Here's a working config I managed to conjure up from various Github and StackOverflow issues (please suggest improvements):
+Here's a working Next.js WASM configuration:
 
 ```javascript
 /** @type {import('next').NextConfig} */
@@ -113,7 +113,7 @@ Also, if you had to fiddle with a bundler or config to get it working, please sh
 
 #### Mobile Support
 
-Completely untested. Maybe yes, maybe no, maybe both.
+Not officially supported yet.
 
 ## fhenix.js sdk
 
@@ -381,4 +381,4 @@ if (savedPermit) {
 }
 ```
 
-For more advanced use cases and detailed API documentation, please refer to our [full documentation](https://fhenixjs.fhenix.zone).
+For more advanced use cases and detailed API documentation, please refer to our [full documentation](https://cofhe-docs.fhenix.zone).


### PR DESCRIPTION
## Summary

The README still references the old `fhenixjs` package throughout. This PR updates all references to correctly point to `cofhejs`.

## Changes

| What | Before | After |
|------|--------|-------|
| npm badge | `fhenixjs` | `cofhejs` |
| CI badge | `fhenixprotocol/fhenix.js` repo | `FhenixProtocol/cofhejs` repo |
| Docs link | `fhenixjs.fhenix.zone` | `cofhe-docs.fhenix.zone` |
| Install command | `npm install fhenixjs` | `npm install cofhejs` |
| CDN URL | `fhenixjs@0.3.0-alpha.1` | `cofhejs` |
| ESM import | `import { fhenixjs } from "./dist/..."` | `import { cofhejs } from "cofhejs/web"` |
| Description | "fhenix.js allows developers..." | "cofhejs allows developers..." |
| Node.js note | "(only node 20+ is supported until I fix this)" | "Node.js 20+ is required." |
| Mobile support | "Completely untested. Maybe yes, maybe no, maybe both." | "Not officially supported yet." |
| WASM note | "config I managed to conjure up from..." | "working Next.js WASM configuration" |

## Test plan

- [ ] Verify npm badge renders correctly for `cofhejs` package
- [ ] Verify docs link resolves to `cofhe-docs.fhenix.zone`

Closes #30